### PR TITLE
Support for JavaScript tagged template literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+test/vim-javascript/
 test/vader.vim/

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@
 
 all: test
 
-test: test/vader.vim
+test: test/vader.vim test/vim-javascript
 	cd test && vim -Nu vimrc -c 'Vader! *' > /dev/null
 
 test/vader.vim:
-	git clone --depth 1 https://github.com/junegunn/vader.vim test/vader.vim
+	git clone --depth 1 https://github.com/junegunn/vader.vim.git test/vader.vim
+
+test/vim-javascript:
+	git clone --depth 1 https://github.com/pangloss/vim-javascript.git test/vim-javascript

--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -1,0 +1,18 @@
+" Prologue; load in GraphQL syntax.
+if exists('b:current_syntax')
+  let s:current_syntax=b:current_syntax
+  unlet b:current_syntax
+endif
+syn include @GraphQLSyntax syntax/graphql.vim
+if exists('s:current_syntax')
+  let b:current_syntax=s:current_syntax
+endif
+
+syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,jsTemplateVar,jsSpecial extend
+exec 'syntax match graphqlTaggedTemplate +\%(' . join(g:graphql_tag_names, '\|') . '\)\%(`\)\@=+ nextgroup=graphqlTemplateString'
+
+hi def link graphqlTemplateString           jsTemplateString
+hi def link graphqlTaggedTemplate           jsTaggedTemplate
+
+syn cluster jsExpression add=graphqlTaggedTemplate
+syn cluster graphqlTaggedTemplate add=graphqlTemplateString

--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -1,18 +1,17 @@
-" Prologue; load in GraphQL syntax.
 if exists('b:current_syntax')
-  let s:current_syntax=b:current_syntax
+  let s:current_syntax = b:current_syntax
   unlet b:current_syntax
 endif
 syn include @GraphQLSyntax syntax/graphql.vim
 if exists('s:current_syntax')
-  let b:current_syntax=s:current_syntax
+  let b:current_syntax = s:current_syntax
 endif
 
-syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,jsTemplateVar,jsSpecial extend
-exec 'syntax match graphqlTaggedTemplate +\%(' . join(g:graphql_tag_names, '\|') . '\)\%(`\)\@=+ nextgroup=graphqlTemplateString'
+syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend
+exec 'syntax match graphqlTaggedTemplate +\%(' . join(g:graphql_javascript_tags, '\|') . '\)\%(`\)\@=+ nextgroup=graphqlTemplateString'
 
-hi def link graphqlTemplateString           jsTemplateString
-hi def link graphqlTaggedTemplate           jsTaggedTemplate
+hi def link graphqlTemplateString jsTemplateString
+hi def link graphqlTaggedTemplate jsTaggedTemplate
 
 syn cluster jsExpression add=graphqlTaggedTemplate
 syn cluster graphqlTaggedTemplate add=graphqlTemplateString

--- a/plugin/graphql.vim
+++ b/plugin/graphql.vim
@@ -1,0 +1,3 @@
+if (!exists('g:graphql_tag_names'))
+  let g:graphql_tag_names = ['gql', 'graphql']
+endif

--- a/plugin/graphql.vim
+++ b/plugin/graphql.vim
@@ -1,3 +1,3 @@
-if (!exists('g:graphql_tag_names'))
-  let g:graphql_tag_names = ['gql', 'graphql']
+if (!exists('g:graphql_javascript_tags'))
+  let g:graphql_javascript_tags = ['gql', 'graphql', 'Relay.QL']
 endif

--- a/test/javascript.vader
+++ b/test/javascript.vader
@@ -1,0 +1,17 @@
+Before:
+  source ../after/syntax/javascript/graphql.vim
+
+Given javascript (Query):
+  const query = gql`
+    {
+      user(id: 5) {
+        firstName
+        lastName
+      }
+    }
+  `
+
+Execute (Syntax assertions):
+  AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
+  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
+  AssertEqual 'graphqlIdentifier', SyntaxOf('user')

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,5 +1,6 @@
 filetype off
-set rtp+=vader.vim
+set rtp+=vader.vim/
+set rtp+=vim-javascript/
 set rtp+=../
 filetype plugin indent on
 syntax enable


### PR DESCRIPTION
Building on #1, this commit makes the following minor changes:

 1. `g:graphql_tag_names` => `g:graphql_javascript_tags`
 2. `jsTemplateVar` => `jsTemplateExpression`, to reflect the change made in pangloss/vim-javascript@88c85d9
 3. Added `Relay.QL` to the list of recognized JavaScript tags
 4. Unit test support