### PR TITLE
Ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-test/vim-javascript/
+doc/tags
 test/vader.vim/
+test/vim-javascript/


### PR DESCRIPTION
Would it be possible to add this so that users managing their vim plugins as git submodules don't have to deal with dirty submodules when tags get generated?