### PR TITLE
Add support for TypeScript

### DIFF
--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -1,0 +1,17 @@
+if exists('b:current_syntax')
+  let s:current_syntax = b:current_syntax
+  unlet b:current_syntax
+endif
+syn include @GraphQLSyntax syntax/graphql.vim
+if exists('s:current_syntax')
+  let b:current_syntax = s:current_syntax
+endif
+
+syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend
+exec 'syntax match graphqlTaggedTemplate +\%(' . join(g:graphql_javascript_tags, '\|') . '\)\%(`\)\@=+ nextgroup=graphqlTemplateString'
+
+hi def link graphqlTemplateString jsTemplateString
+hi def link graphqlTaggedTemplate jsTaggedTemplate
+
+syn cluster jsExpression add=graphqlTaggedTemplate
+syn cluster graphqlTaggedTemplate add=graphqlTemplateString

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -7,11 +7,13 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend
+" TODO check corresponding in typescript
+syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateTag,jsSpecial extend
 exec 'syntax match graphqlTaggedTemplate +\%(' . join(g:graphql_javascript_tags, '\|') . '\)\%(`\)\@=+ nextgroup=graphqlTemplateString'
 
-hi def link graphqlTemplateString jsTemplateString
+hi def link graphqlTemplateString typescriptTemplate
+" TODO check corresponding in typescript
 hi def link graphqlTaggedTemplate jsTaggedTemplate
 
-syn cluster jsExpression add=graphqlTaggedTemplate
+syn cluster typescriptExpression add=graphqlTaggedTemplate
 syn cluster graphqlTaggedTemplate add=graphqlTemplateString

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -7,13 +7,10 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-" TODO check corresponding in typescript
-syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateTag,jsSpecial extend
+syntax region graphqlTemplateString start=+`+ skip=+\\\(`\|$\)+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateTag extend
 exec 'syntax match graphqlTaggedTemplate +\%(' . join(g:graphql_javascript_tags, '\|') . '\)\%(`\)\@=+ nextgroup=graphqlTemplateString'
 
 hi def link graphqlTemplateString typescriptTemplate
-" TODO check corresponding in typescript
-hi def link graphqlTaggedTemplate jsTaggedTemplate
 
 syn cluster typescriptExpression add=graphqlTaggedTemplate
 syn cluster graphqlTaggedTemplate add=graphqlTemplateString

--- a/test/typescript.vader
+++ b/test/typescript.vader
@@ -1,0 +1,32 @@
+Before:
+  Save g:graphql_javascript_tags
+
+  source ../after/syntax/typescript/graphql.vim
+
+After:
+  Restore
+
+Given typescript (Query):
+  const query = gql`
+    {
+      user(id: 5) {
+        firstName
+        lastName
+      }
+    }
+  `
+
+Execute (Syntax assertions):
+  AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
+  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
+  AssertEqual 'graphqlName', SyntaxOf('user')
+
+Given typescript (Custom tag):
+  const query = GraphQL.Tag`
+    { }
+  `
+
+Execute (JavaScript tag names can be customized):
+  let g:graphql_javascript_tags = ['GraphQL.Tag']
+  source ../after/syntax/typescript/graphql.vim
+  AssertEqual 'graphqlTaggedTemplate', SyntaxOf('GraphQL.Tag')


### PR DESCRIPTION
I've added support for typescript, using yats as reference TypeScript plugin implementation

There is just a minor issue, that the tag matching the graphql name doesn't get highlighted anymore..
However I didn't find the way to fix it (I'm not vimscript ninja xD)