### PR TITLE
use a default shiftwidth of 2

### DIFF
--- a/ftplugin/graphql.vim
+++ b/ftplugin/graphql.vim
@@ -11,3 +11,7 @@ setlocal comments=:#
 setlocal commentstring=#\ %s
 setlocal formatoptions-=t
 setlocal iskeyword+=$,@-@
+setlocal tabstop=2
+setlocal softtabstop=2
+setlocal shiftwidth=2
+setlocal expandtab


### PR DESCRIPTION
I can't seem to find the coding style guide for graphql, perhaps they just don't have one.

But they are using a 2 space indentation through out their websites, like http://graphql.org/learn/queries/.

So I figured it'd be nice of vim-graphql to apply the official style as the default.