### PR TITLE
Use an autoloaded function to get JavaScript tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: lint test
 
 lint: test/vim-vimhelplint
-	vint -s after ftdetect ftplugin indent plugin syntax
+	vint -s after autoload ftdetect ftplugin indent syntax
 	vim -esN --cmd 'set rtp+=test/vim-vimhelplint' \
 		-c 'filetype plugin on' \
 		-c 'e doc/graphql.txt' \

--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -7,7 +7,7 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-let s:tags = '\%(' . join(g:graphql_javascript_tags, '\|') . '\)'
+let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
 
 exec 'syntax region graphqlTemplateString start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
 exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -7,7 +7,7 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-let s:tags = '\%(' . join(g:graphql_javascript_tags, '\|') . '\)'
+let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
 
 exec 'syntax region graphqlTemplateString start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution extend'
 exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'

--- a/autoload/graphql.vim
+++ b/autoload/graphql.vim
@@ -1,0 +1,12 @@
+" Vim plugin
+" Language: GraphQL
+" Maintainer: Jon Parise <jon@indelible.org>
+
+if exists('g:autoloaded_graphql')
+  finish
+endif
+let g:autoloaded_graphql = 1
+
+function! graphql#javascript_tags() abort
+  return get(g:, 'graphql_javascript_tags', ['gql', 'graphql', 'Relay.QL'])
+endfunction

--- a/plugin/graphql.vim
+++ b/plugin/graphql.vim
@@ -1,7 +1,0 @@
-" Vim plugin
-" Language: GraphQL
-" Maintainer: Jon Parise <jon@indelible.org>
-"
-if (!exists('g:graphql_javascript_tags'))
-  let g:graphql_javascript_tags = ['gql', 'graphql', 'Relay.QL']
-endif


### PR DESCRIPTION
We previously relied on the main plugin script to set the global
`g:graphql_javascript_tags` variable if it wasn't already set by the
user. However, there are some legitimate cases when the plugin script
wouldn't be loaded before the `after/` syntax files (see #25), resulting
in the global variable not being set at all.

Using an autoload script addresses that shortcoming because vim will
load it on-demand when the `after/` syntax files are sourced.