### PR TITLE
Document how to enable syntax for custom extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Complete syntax highlighting is enable for the `graphql` [filetype][]. This
 filetype is automatically selected for file names ending in `.graphql`,
 `.graphqls`, and `.gql`.
 
+If you would like to enable syntax support for custom extensions, for example
+`.prisma`, create a new file named `~/.vim/ftdetect/prisma.vim` containing:
+
+```vim
+au BufNewFile,BufRead *.prisma setfiletype graphql
+```
+
 [filetype]: http://vimdoc.sourceforge.net/htmldoc/filetype.html
 
 ## JavaScript / TypeScript Support


### PR DESCRIPTION
closes https://github.com/jparise/vim-graphql/issues/30

Document how to enable syntax for custom extensions since there is no
plan to add built-in support to this stock plugin at this point.
See: https://github.com/jparise/vim-graphql/issues/7#issuecomment-325139103