### PR TITLE
Skip escaped triple quotes in block strings

### DIFF
--- a/syntax/graphql.vim
+++ b/syntax/graphql.vim
@@ -17,7 +17,7 @@ syn keyword graphqlBoolean  true false
 syn keyword graphqlNull     null
 syn match   graphqlNumber   "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>" display
 syn region  graphqlString   start=+"+  skip=+\\\\\|\\"+  end=+"\|$+
-syn region  graphqlString   start=+"""+ end=+"""+
+syn region  graphqlString   start=+"""+ skip=+\\"""+ end=+"""+
 
 syn keyword graphqlKeyword on nextgroup=graphqlType skipwhite
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -39,13 +39,19 @@ Execute (Boolean assertions):
 Given graphql (Strings):
   ""
   "Hello World"
-  """Triple-quoted
+
+  """Block
+  string"""
+
+  """Block
+  \"""
   string"""
 
 Execute (String assertions):
   AssertEqual 'graphqlString', SyntaxOf('""')
   AssertEqual 'graphqlString', SyntaxOf('"Hello World"')
-  AssertEqual 'graphqlString', SyntaxOf('"""Triple-quoted\nstring"""')
+  AssertEqual 'graphqlString', SyntaxOf('"""Block\nstring"""')
+  AssertEqual 'graphqlString', SyntaxOf('"""Block\n\\"""\nstring"""')
 
 # https://facebook.github.io/graphql/October2016/#sec-Language.Arguments
 Given graphql (Arguments):


### PR DESCRIPTION
Previously, we weren't skipped \""" sequences within block strings. That
caused the block string to terminate early and then start a second,
unintended block string once we hit the terminating """ sequence.