### PR TITLE
Improve syntax highlighting for directives

### DIFF
--- a/syntax/graphql.vim
+++ b/syntax/graphql.vim
@@ -6,6 +6,8 @@ if exists('b:current_syntax')
     finish
 endif
 
+syn case match
+
 syn match graphqlComment    "#.*$" contains=@Spell
 
 syn match graphqlOperator   "=" display
@@ -19,7 +21,7 @@ syn match   graphqlNumber   "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+
 syn region  graphqlString   start=+"+  skip=+\\\\\|\\"+  end=+"\|$+
 syn region  graphqlString   start=+"""+ skip=+\\"""+ end=+"""+
 
-syn keyword graphqlKeyword on nextgroup=graphqlType skipwhite
+syn keyword graphqlKeyword on nextgroup=graphqlType,graphqlDirectiveLocation skipwhite
 
 syn keyword graphqlStructure enum scalar type union nextgroup=graphqlType skipwhite
 syn keyword graphqlStructure input interface subscription nextgroup=graphqlType skipwhite
@@ -34,6 +36,16 @@ syn match graphqlVariable   "\<\$\h\w*\>"  display
 syn match graphqlName       "\<\h\w*\>"    display
 syn match graphqlType       "\<_*\u\w*\>"  display
 syn match graphqlConstant   "\<[_A-Z][_A-Z0-9]*\>" display
+
+" https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation
+syn keyword graphqlDirectiveLocation QUERY MUTATION SUBSCRIPTION FIELD
+syn keyword graphqlDirectiveLocation FRAGMENT_DEFINITION FRAGMENT_SPREAD
+syn keyword graphqlDirectiveLocation INLINE_FRAGMENT
+" https://graphql.github.io/graphql-spec/June2018/#TypeSystemDirectiveLocation
+syn keyword graphqlDirectiveLocation SCHEMA SCALAR OBJECT FIELD_DEFINITION
+syn keyword graphqlDirectiveLocation ARGUMENT_DEFINITION INTERFACE UNION
+syn keyword graphqlDirectiveLocation ENUM ENUM_VALUE INPUT_OBJECT
+syn keyword graphqlDirectiveLocation INPUT_FIELD_DEFINITION
 
 syn keyword graphqlMetaFields __schema __type __typename
 
@@ -52,6 +64,7 @@ hi def link graphqlString           String
 
 hi def link graphqlConstant         Constant
 hi def link graphqlDirective        PreProc
+hi def link graphqlDirectiveLocation Special
 hi def link graphqlName             Identifier
 hi def link graphqlMetaFields       Special
 hi def link graphqlKeyword          Keyword

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -119,3 +119,19 @@ Execute (Schema assertions):
   AssertEqual 'graphqlStructure', SyntaxOf('schema')
   AssertEqual 'graphqlName', SyntaxOf('query')
   AssertEqual 'graphqlType', SyntaxOf('QueryType')
+
+# https://graphql.github.io/graphql-spec/June2018/#sec-Type-System.Directives
+Given graphql (Directives):
+  directive @include(if: Boolean!)
+    on FIELD
+      | FRAGMENT_SPREAD
+      | INLINE_FRAGMENT
+
+Execute (Directive assertions):
+  AssertEqual 'graphqlStructure', SyntaxOf('directive')
+  AssertEqual 'graphqlDirective', SyntaxOf('@include')
+  AssertEqual 'graphqlKeyword', SyntaxOf('on')
+  AssertEqual 'graphqlDirectiveLocation', SyntaxOf('FIELD')
+  AssertEqual 'graphqlDirectiveLocation', SyntaxOf('FRAGMENT_SPREAD')
+  AssertEqual 'graphqlDirectiveLocation', SyntaxOf('INLINE_FRAGMENT')
+  AssertEqual 'graphqlOperator', SyntaxOf('|')


### PR DESCRIPTION
This specifically adds support for highlighting directive locations
(e.g. FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT) which appear as part of
a directive's `on` clause.