### PR TITLE
Use Vim 8.2's built-in TypeScript syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint: .bundle/vim-vimhelplint
 		-c 'verb VimhelpLintEcho' \
 		-c q
 
-test: .bundle/vader.vim .bundle/vim-javascript .bundle/yats.vim
+test: .bundle/vader.vim .bundle/vim-javascript
 	cd test && vim -EsNu vimrc --not-a-term -c 'Vader! * */*'
 
 .bundle/vader.vim:
@@ -21,6 +21,3 @@ test: .bundle/vader.vim .bundle/vim-javascript .bundle/yats.vim
 
 .bundle/vim-vimhelplint:
 	git clone --depth 1 https://github.com/machakann/vim-vimhelplint.git .bundle/vim-vimhelplint
-
-.bundle/yats.vim:
-	git clone --depth 1 https://github.com/HerringtonDarkholme/yats.vim.git .bundle/yats.vim

--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ au BufNewFile,BufRead *.prisma setfiletype graphql
 
 [filetype]: http://vimdoc.sourceforge.net/htmldoc/filetype.html
 
-## JavaScript / TypeScript Support
+## JavaScript and TypeScript Support
 
-GraphQL syntax support in [ES2015 template literals][templates] is provided.
-It works "out of the box" with Vim 8.2's JavaScript support. The extended
-syntax support proved by the [vim-javascript][] plugin is also supported.
+GraphQL syntax support inside of [ES2015 template literals][templates] is
+provided. It works "out of the box" with Vim 8.2+'s JavaScript and TypeScript
+language support. The extended JavaScript syntax provided by the
+[vim-javascript][] plugin is also supported.
 
-TypeScript support is also available when the [yats][] plugin is installed.
+For older versions of Vim, TypeScript support can be enabled by installing the
+[yats][] plugin.
 
 [templates]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_templates
 [vim-javascript]: https://github.com/pangloss/vim-javascript

--- a/doc/graphql.txt
+++ b/doc/graphql.txt
@@ -33,11 +33,13 @@ supported.
 
 TYPESCRIPT                                                *graphql-typescript*
 
-When the yats (https://github.com/HerringtonDarkholme/yats.vim) plugin is
-installed, GraphQL syntax support in ES2015 tagged templates is enabled.
+Like |graphql-javascript|, GraphQL syntax support in ES2015 template literals
+is provided. It also works "out of the box" with Vim 8.2's TypeScript support,
+which is based on the yats (https://github.com/HerringtonDarkholme/yats.vim)
+plugin. For older versions, you can install yats directly.
 
-TypeScript support also uses |graphql-javascript-options| to customize the
-list of recognized template tag names.
+TypeScript syntax support also uses |graphql-javascript-options| to customize
+the list of recognized template tag names.
 
 ------------------------------------------------------------------------------
 vim:tw=78:ft=help:norl:

--- a/test/typescript.vader
+++ b/test/typescript.vader
@@ -6,6 +6,9 @@ Before:
 After:
   Restore
 
+Execute (Expected syntax groups):
+  Assert graphql#has_syntax_group('typescriptTemplate')
+
 Given typescript (Template):
   const query = gql`
     {

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,6 +1,5 @@
 filetype off
 set runtimepath+=../.bundle/vader.vim/
-set runtimepath+=../.bundle/yats.vim/
 set runtimepath+=../
 filetype plugin indent on
 syntax enable


### PR DESCRIPTION
This is conveniently based on yats, so we don't need to support multiple
sets of syntax groups using runtime detection. It also means that users
can just install yats to get TypeScript support for older Vim versions.