### PR TITLE
Add syntax highlighting support for Vue

### DIFF
--- a/after/syntax/vue/graphql.vim
+++ b/after/syntax/vue/graphql.vim
@@ -1,0 +1,1 @@
+runtime! after/syntax/javascript/graphql.vim

--- a/test/javascript/vue.vader
+++ b/test/javascript/vue.vader
@@ -1,0 +1,34 @@
+Before:
+  Save &runtimepath
+  filetype off
+  set runtimepath+=../.bundle/vim-javascript/
+  filetype plugin indent on
+  syntax enable
+
+  source ../after/syntax/vue/graphql.vim
+
+After:
+  filetype off
+  Restore &runtimepath
+  filetype plugin indent on
+  syntax enable
+
+Execute (Expected syntax groups):
+  Assert graphql#has_syntax_group('graphqlTemplateExpression')
+  Assert graphql#has_syntax_group('graphqlTemplateString')
+
+Given vue (Template):
+  <script>
+  export default {
+    apollo: {
+      hello: gql`query {
+        hello
+      }`,
+    },
+  }
+  </script>
+
+Execute (Syntax assertions):
+  AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
+  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
+  AssertEqual 'graphqlStructure', SyntaxOf('query')


### PR DESCRIPTION
This change adds GraphQL syntax support for JavaScript embedded within
Vue templates.

At the moment, this requires the extended JavaScript language support
provided by the vim-javascript plugin because there's a deficiency in
our base JavaScript support that prevents embedded GraphQL from being
recognized within embedded JavaScript. I'll work on that separately.

Closes #26