### PR TITLE
Remove the graphqlConstant syntax definition

### DIFF
--- a/syntax/graphql.vim
+++ b/syntax/graphql.vim
@@ -36,7 +36,6 @@ syn match graphqlDirective  "\<@\h\w*\>"   display
 syn match graphqlVariable   "\<\$\h\w*\>"  display
 syn match graphqlName       "\<\h\w*\>"    display
 syn match graphqlType       "\<_*\u\w*\>"  display
-syn match graphqlConstant   "\<[_A-Z][_A-Z0-9]*\>" display
 
 " https://graphql.github.io/graphql-spec/June2018/#ExecutableDirectiveLocation
 syn keyword graphqlDirectiveLocation QUERY MUTATION SUBSCRIPTION FIELD
@@ -63,7 +62,6 @@ hi def link graphqlNull             Keyword
 hi def link graphqlNumber           Number
 hi def link graphqlString           String
 
-hi def link graphqlConstant         Constant
 hi def link graphqlDirective        PreProc
 hi def link graphqlDirectiveLocation Special
 hi def link graphqlName             Identifier

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -65,7 +65,7 @@ Execute (Argument assertions):
   AssertEqual 'graphqlName', SyntaxOf('queryName')
   AssertEqual 'graphqlVariable', SyntaxOf('$site')
   AssertEqual 'graphqlType', SyntaxOf('Site')
-  AssertEqual 'graphqlConstant', SyntaxOf('MOBILE')
+  AssertEqual 'graphqlType', SyntaxOf('MOBILE')
   AssertEqual 'graphqlName', SyntaxOf('id')
   AssertEqual 'graphqlNumber', SyntaxOf('4')
   AssertEqual 'graphqlName', SyntaxOf('size')


### PR DESCRIPTION
Constants don't exist in the GraphQL language. I originally added this
syntax definition to cover `enum` values (which are written in ALL_CAPS
by convention) and directive locations.

Unfortunately, this syntax unintentionally matched a few other cases,
such as standard object names that happened to be spelled with CAPS.

Because it's not an official part of the GraphQL grammar, I decided the
best approach was to remove `graphqlConstant`. In 4c2fdadc, I added
explicit support for directive locations, so that case is now handled
correctly. `enum` values will now just be highlighted as `graphqlType`,
which is reasonable.

Fixes #18 