### PR TITLE
Stop installing a specific vim patch version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - master
 
 jobs:
-  build:
+  checks:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,10 +19,10 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Install vim (8.2)
+      - name: Install vim
         run: |
           sudo add-apt-repository ppa:jonathonf/vim
-          sudo apt install vim=2:8.2.0012-0york0~18.04
+          sudo apt install vim
       - name: Run lint
         run: |
           pip install vim-vint==0.3.21


### PR DESCRIPTION
This PPA doesn't keep all versions indefinitely.
Instead, always install the latest version.