### PR TITLE
GraphQL indentation inside of JavaScript strings

### DIFF
--- a/after/indent/javascript.vim
+++ b/after/indent/javascript.vim
@@ -1,0 +1,43 @@
+" Copyright (c) 2016-2020 Jon Parise <jon@indelible.org>
+"
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the "Software"), to
+" deal in the Software without restriction, including without limitation the
+" rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+" sell copies of the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+"
+" The above copyright notice and this permission notice shall be included in
+" all copies or substantial portions of the Software.
+"
+" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+" FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+" IN THE SOFTWARE.
+"
+" Language: GraphQL
+" Maintainer: Jon Parise <jon@indelible.org>
+
+runtime! indent/graphql.vim
+
+" Don't redefine our function and also require the standard Javascript indent
+" function to exist.
+if exists('*GetJavascriptGraphQLIndent') || !exists('*GetJavascriptIndent')
+  finish
+endif
+
+" Set the indentexpr with our own version that will call GetGraphQLIndent when
+" we're inside of a GraphQL string and otherwise defer to GetJavascriptIndent.
+setlocal indentexpr=GetJavascriptGraphQLIndent()
+
+function GetJavascriptGraphQLIndent()
+  let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val,'name')")
+  if !empty(l:stack) && l:stack[0] ==# 'graphqlTemplateString'
+    return GetGraphQLIndent()
+  endif
+
+  return GetJavascriptIndent()
+endfunction

--- a/after/indent/typescript.vim
+++ b/after/indent/typescript.vim
@@ -1,0 +1,43 @@
+" Copyright (c) 2016-2020 Jon Parise <jon@indelible.org>
+"
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the "Software"), to
+" deal in the Software without restriction, including without limitation the
+" rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+" sell copies of the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+"
+" The above copyright notice and this permission notice shall be included in
+" all copies or substantial portions of the Software.
+"
+" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+" FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+" IN THE SOFTWARE.
+"
+" Language: GraphQL
+" Maintainer: Jon Parise <jon@indelible.org>
+
+runtime! indent/graphql.vim
+
+" Don't redefine our function and also require the standard Typescript indent
+" function to exist.
+if exists('*GetTypescriptGraphQLIndent') || !exists('*GetTypescriptIndent')
+  finish
+endif
+
+" Set the indentexpr with our own version that will call GetGraphQLIndent when
+" we're inside of a GraphQL string and otherwise defer to GetTypescriptIndent.
+setlocal indentexpr=GetTypescriptGraphQLIndent()
+
+function GetTypescriptGraphQLIndent()
+  let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val,'name')")
+  if !empty(l:stack) && l:stack[0] ==# 'graphqlTemplateString'
+    return GetGraphQLIndent()
+  endif
+
+  return GetTypescriptIndent()
+endfunction

--- a/indent/graphql.vim
+++ b/indent/graphql.vim
@@ -21,18 +21,19 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-if exists('b:did_indent')
-  finish
+" Set our local options if indentation hasn't already been set up.
+" This generally means we've been detected as the primary filetype.
+if !exists('b:did_indent')
+  setlocal autoindent
+  setlocal nocindent
+  setlocal nolisp
+  setlocal nosmartindent
+
+  setlocal indentexpr=GetGraphQLIndent()
+  setlocal indentkeys=0{,0},0),0[,0],0#,!^F,o,O
+
+  let b:did_indent = 1
 endif
-let b:did_indent = 1
-
-setlocal autoindent
-setlocal nocindent
-setlocal nolisp
-setlocal nosmartindent
-
-setlocal indentexpr=GetGraphQLIndent()
-setlocal indentkeys=0{,0},0),0[,0],0#,!^F,o,O
 
 " If our indentation function already exists, we have nothing more to do.
 if exists('*GetGraphQLIndent')
@@ -44,7 +45,7 @@ set cpoptions&vim
 
 " Check if the character at lnum:col is inside a string.
 function s:InString(lnum, col)
-  return synIDattr(synID(a:lnum, a:col, 1), 'name') is# 'graphqlString'
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') ==# 'graphqlString'
 endfunction
 
 function GetGraphQLIndent()

--- a/test/javascript/default.vader
+++ b/test/javascript/default.vader
@@ -1,6 +1,8 @@
 Before:
   Save g:graphql_javascript_tags
 
+  setlocal shiftwidth=2
+  source ../after/indent/javascript.vim
   source ../after/syntax/javascript/graphql.vim
 
 After:
@@ -21,6 +23,24 @@ Execute (Syntax assertions):
   AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlTemplateExpression', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
+
+Execute (Indent assertions):
+  Assert exists('*GetGraphQLIndent')
+  Assert exists('*GetJavascriptIndent')
+  Assert exists('*GetJavascriptGraphQLIndent')
+
+Do (re-indent buffer):
+  gg=G
+
+Expect (propertly indented):
+  const query = gql`
+    {
+      user(id: ${uid}) {
+        firstName
+        lastName
+      }
+    }
+  `;
 
 Given javascript (Custom tag):
   const query = GraphQL.Tag`{}`;

--- a/test/javascript/react.vader
+++ b/test/javascript/react.vader
@@ -1,4 +1,5 @@
 Before:
+  source ../after/indent/javascript.vim
   source ../after/syntax/javascriptreact/graphql.vim
 
 Execute (Expected syntax groups):
@@ -20,3 +21,8 @@ Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
   AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlBraces', SyntaxOf('{}')
+
+Execute (Indent assertions):
+  Assert exists('*GetGraphQLIndent')
+  Assert exists('*GetJavascriptIndent')
+  Assert exists('*GetJavascriptGraphQLIndent')

--- a/test/javascript/vue.vader
+++ b/test/javascript/vue.vader
@@ -5,6 +5,8 @@ Before:
   filetype plugin indent on
   syntax enable
 
+  setlocal shiftwidth=2
+  source ../after/indent/javascript.vim
   source ../after/syntax/vue/graphql.vim
 
 After:
@@ -22,7 +24,8 @@ Given vue (Template):
   export default {
     apollo: {
       hello: gql`query {
-        hello
+        firstName
+        lastName
       }`,
     },
   }
@@ -32,3 +35,23 @@ Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
   AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlStructure', SyntaxOf('query')
+
+Execute (Indent assertions):
+  Assert exists('*GetGraphQLIndent')
+  Assert exists('*GetJavascriptIndent')
+  Assert exists('*GetJavascriptGraphQLIndent')
+
+Do (re-indent buffer):
+  gg=G
+
+Expect (propertly indented):
+  <script>
+  export default {
+    apollo: {
+      hello: gql`query {
+        firstName
+        lastName
+      }`,
+    },
+  }
+  </script>

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -1,6 +1,8 @@
 Before:
   Save g:graphql_javascript_tags
 
+  setlocal shiftwidth=2
+  source ../after/indent/typescript.vim
   source ../after/syntax/typescript/graphql.vim
 
 After:
@@ -24,6 +26,24 @@ Execute (Syntax assertions):
   AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'typescriptTemplateSB', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
+
+Execute (Indent assertions):
+  Assert exists('*GetGraphQLIndent')
+  Assert exists('*GetTypescriptIndent')
+  Assert exists('*GetTypescriptGraphQLIndent')
+
+Do (re-indent buffer):
+  gg=G
+
+Expect (properly indented):
+  const query = gql`
+  {
+    user(id: ${uid}) {
+      firstName
+      lastName
+    }
+  }
+  `;
 
 Given typescript (Custom tag):
   const query = GraphQL.Tag`{}`;


### PR DESCRIPTION
This builds upon the embedded syntax "magic" we perform in order to
identify and highlight GraphQL queries within JavaScript/TypeScript
template strings.

In order to enable GraphQL syntax-aware indentation within these
strings, we replace `'indentexpr'` with our own function which calls
`GetGraphQLIndent` inside of a GraphQL syntax region and otherwise
defers to the indentation function provided by the filetype plugin.

To support loading `indent/graphql.vim` inside of other file types, it
no longer sets any buffer-local settings when `b:did_indent` is already
set. This means we use the "outer" JavaScript indentation settings for
the "inner" GraphQL region. In practice, this is probably only relevant
for `'indentkeys'`; I haven't thought of a way to make that setting
syntax-aware, too, without also changing it for the JavaScript code.

This approach has been tested with all of the supported JavaScript and
TypeScript variants, but there still may be some lingering issues that I
haven't encountered yet.

Fixes #24, #54 