### PR TITLE
`vim-reasonml` is not necessary to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ templates.
 ## ReasonML Support
 
 GraphQL syntax support inside of [ReasonML](https://reasonml.org/) template
-strings using [graphql-ppx][] is available when [vim-reasonml][] is also
-installed.
+strings using [graphql-ppx][] is available.
 
 ```reason
 [%graphql {|
@@ -90,7 +89,6 @@ installed.
 ```
 
 [graphql-ppx]: https://github.com/reasonml-community/graphql-ppx
-[vim-reasonml]: https://github.com/jordwalke/vim-reasonml
 
 ## Testing
 

--- a/doc/graphql.txt
+++ b/doc/graphql.txt
@@ -44,8 +44,7 @@ the list of recognized template tag names.
 REASONML                                                    *graphql-reasonml*
 
 GraphQL syntax support inside of ReasonML template strings using graphql-ppx
-is available when vim-reasonml (https://github.com/jordwalke/vim-reasonml) is
-also installed.
+is available.
 
 ------------------------------------------------------------------------------
 vim:tw=78:ft=help:norl:


### PR DESCRIPTION
There are a few reasonml language server option. Probably the best one at the moment is https://github.com/reasonml-editor/vim-reason-plus but since you can use any syntax highlighter I suggest to remove that reference.