### PR TITLE
Fix reason syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint: .bundle/vim-vimhelplint
 		-c 'verb VimhelpLintEcho' \
 		-c q
 
-test: .bundle/vader.vim .bundle/vim-javascript .bundle/vim-reasonml
+test: .bundle/vader.vim .bundle/vim-javascript 
 	cd test && vim -EsNu vimrc --not-a-term -c 'Vader! * */*'
 
 .bundle/vader.vim:
@@ -18,9 +18,6 @@ test: .bundle/vader.vim .bundle/vim-javascript .bundle/vim-reasonml
 
 .bundle/vim-javascript:
 	git clone --depth 1 https://github.com/pangloss/vim-javascript.git .bundle/vim-javascript
-
-.bundle/vim-reasonml:
-	git clone --depth 1 https://github.com/jordwalke/vim-reasonml .bundle/vim-reasonml
 
 .bundle/vim-vimhelplint:
 	git clone --depth 1 https://github.com/machakann/vim-vimhelplint.git .bundle/vim-vimhelplint

--- a/after/syntax/reason/graphql.vim
+++ b/after/syntax/reason/graphql.vim
@@ -30,4 +30,4 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-syntax region graphqlExtensionPoint start=/\[%graphql\s*\n\s*{|/ end=/|}\s*\n\s*\]/ contains=@GraphQLSyntax keepend
+syntax region graphqlMultilineString start=/\[%graphql\s*\n\s*{|/ end=/|}\s*\n\s*\]/ contains=@GraphQLSyntax keepend

--- a/after/syntax/reason/graphql.vim
+++ b/after/syntax/reason/graphql.vim
@@ -30,4 +30,4 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-syntax region graphqlMultilineString matchgroup=reasonMultilineString start=+graphql\_s*\zs{|+ end=+|}+ contains=@GraphQLSyntax,reasonEscape,reasonEscapeUnicode,reasonEscapeError,reasonStringContinuation keepend
+syntax region graphqlExtensionPoint start=/\[%graphql\s*\n\s*{|/ end=/|}\s*\n\s*\]/ contains=@GraphQLSyntax keepend

--- a/after/syntax/reason/graphql.vim
+++ b/after/syntax/reason/graphql.vim
@@ -30,4 +30,4 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-syntax region graphqlMultilineString start=/\[%graphql\s*\n\s*{|/ end=/|}\s*\n\s*\]/ contains=@GraphQLSyntax keepend
+syntax region graphqlMultilineString start=/\[%graphql\s*\n*\s*{|/ end=/|}\s*\n\s*\]/ contains=@GraphQLSyntax keepend

--- a/test/reason/vim-reasonml.vader
+++ b/test/reason/vim-reasonml.vader
@@ -1,9 +1,5 @@
 Before:
-  set filetype=reason
   source ../after/syntax/reason/graphql.vim
-
-Execute (Expected syntax groups):
-  Assert graphql#has_syntax_group('reasonMultilineString')
 
 Given reason (Template):
   [%graphql {|

--- a/test/reason/vim-reasonml.vader
+++ b/test/reason/vim-reasonml.vader
@@ -1,8 +1,9 @@
 Before:
+  set filetype=reason
   source ../after/syntax/reason/graphql.vim
 
 Execute (Expected syntax groups):
-  Assert graphql#has_syntax_group('graphqlMultilineString')
+  Assert graphql#has_syntax_group('reasonMultilineString')
 
 Given reason (Template):
   [%graphql {|


### PR DESCRIPTION
The change was incorrect and due to the change, the highlighting didn't work anymore. We cannot match within a multiline string because it needs to match an "extension point" everything that happens inside that extension point is basically taken care of by the language extension. I also removed the extra items in contains, I am not sure why that needs to be there because it contains no reason at all, just GraphQL syntax. Also, the current change is independent of the reason-syntax you use.