### PR TITLE
Skip comments and strings when matching brackets

### DIFF
--- a/indent/graphql.vim
+++ b/indent/graphql.vim
@@ -43,6 +43,10 @@ endif
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
+" searchpair() skip expression that matches in comments and strings.
+let s:pair_skip_expr =
+  \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "comment\\|string"'
+
 " Check if the character at lnum:col is inside a string.
 function s:InString(lnum, col)
   return synIDattr(synID(a:lnum, a:col, 1), 'name') ==# 'graphqlString'
@@ -66,11 +70,11 @@ function GetGraphQLIndent()
 
     let l:bracket = l:line[l:col - 1]
     if l:bracket ==# '}'
-      let l:matched = searchpair('{', '', '}', 'bW')
+      let l:matched = searchpair('{', '', '}', 'bW', s:pair_skip_expr)
     elseif l:bracket ==# ']'
-      let l:matched = searchpair('\[', '', '\]', 'bW')
+      let l:matched = searchpair('\[', '', '\]', 'bW', s:pair_skip_expr)
     elseif l:bracket ==# ')'
-      let l:matched = searchpair('(', '', ')', 'bW')
+      let l:matched = searchpair('(', '', ')', 'bW', s:pair_skip_expr)
     else
       let l:matched = -1
     endif
@@ -83,9 +87,8 @@ function GetGraphQLIndent()
     return indent(v:lnum)
   endif
 
-  " If the previous line contained an opening bracket, and we are still in it,
-  " add indent depending on the bracket type.
-  if getline(l:prevlnum) =~# '[[{(]\s*$'
+  " If the previous line ended with an opening bracket, indent this line.
+  if getline(l:prevlnum) =~# '\%(#.*\)\@<![[{(]\s*$'
     return indent(l:prevlnum) + shiftwidth()
   endif
 

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -61,3 +61,22 @@ Expect (new comment is indented at the existing level):
   query {
     field
     # comment
+
+Given graphql:
+  query {
+    # Comment {
+    field("string {") {
+      id
+    }
+  }
+
+Do (reindent):
+  gg=G
+
+Expect (brackets in comments and strings are ignored):
+  query {
+    # Comment {
+    field("string {") {
+      id
+    }
+  }


### PR DESCRIPTION
When searching backwards for a matching bracket, we use searchpair()'s
'skip' expression to ignore any candidates inside of strings and
comments.

When checking whether the previous line ends in an opening bracket, we
exclude any matches that are part of a comment.