### PR TITLE
Use base syntax groups for templates boundaries

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -34,7 +34,7 @@ let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
 
 if graphql#has_syntax_group('jsTemplateExpression')
   " pangloss/vim-javascript
-  exec 'syntax region graphqlTemplateString start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
+  exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
   exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
   syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=jsTemplateExpression containedin=graphqlFold keepend
 
@@ -46,7 +46,7 @@ if graphql#has_syntax_group('jsTemplateExpression')
   syn cluster graphqlTaggedTemplate add=graphqlTemplateString
 elseif graphql#has_syntax_group('javaScriptStringT')
   " runtime/syntax/javascript.vim
-  exec 'syntax region graphqlTemplateString start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend'
+  exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend'
   exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
   syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=@javaScriptEmbededExpr containedin=graphqlFold keepend
 

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -32,7 +32,7 @@ endif
 
 let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
 
-exec 'syntax region graphqlTemplateString start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution extend'
+exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution extend'
 exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
 
 " Support expression interpolation ((${...})) inside template strings.

--- a/test/javascript/default.vader
+++ b/test/javascript/default.vader
@@ -20,7 +20,6 @@ Given javascript (Template):
 
 Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
-  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlTemplateExpression', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
 

--- a/test/javascript/react.vader
+++ b/test/javascript/react.vader
@@ -11,7 +11,6 @@ Given javascriptreact (Template):
 
 Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
-  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlBraces', SyntaxOf('{}')
 
 Given javascript.jsx (Template):
@@ -19,7 +18,6 @@ Given javascript.jsx (Template):
 
 Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
-  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlBraces', SyntaxOf('{}')
 
 Execute (Indent assertions):

--- a/test/javascript/vue.vader
+++ b/test/javascript/vue.vader
@@ -33,7 +33,6 @@ Given vue (Template):
 
 Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
-  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlStructure', SyntaxOf('query')
 
 Execute (Indent assertions):

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -23,7 +23,6 @@ Given typescript (Template):
 
 Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
-  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'typescriptTemplateSB', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
 

--- a/test/typescript/react.vader
+++ b/test/typescript/react.vader
@@ -10,7 +10,6 @@ Given typescriptreact (Template):
 
 Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
-  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlBraces', SyntaxOf('{}')
 
 Given typescript.tsx (Template):
@@ -18,5 +17,4 @@ Given typescript.tsx (Template):
 
 Execute (Syntax assertions):
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
-  AssertEqual 'graphqlTemplateString', SyntaxOf('`')
   AssertEqual 'graphqlBraces', SyntaxOf('{}')


### PR DESCRIPTION
In order to match GraphQL syntax inside of template strings, we recreate
the JavaScript/TypeScript template string syntax regions and embed our
syntax within them. These region's 'start' and 'end' patterns were
therefore being matched using our syntax groups.

Instead, use 'matchgroup=' to explicitly match the boundaries using the
base syntax's groups. This better integrates with those filetype's
natural syntax and indentation definitions while still giving us control
over the embedded GraphQL syntax.