### PR TITLE
Attempt to honor indentation within templates

### DIFF
--- a/indent/graphql.vim
+++ b/indent/graphql.vim
@@ -60,6 +60,13 @@ function GetGraphQLIndent()
     return 0
   endif
 
+  " If the previous line isn't GraphQL, don't change this line's indentation.
+  " Assume we've been manually indented as part of a template string.
+  let l:stack = map(synstack(l:prevlnum, 1), "synIDattr(v:val, 'name')")
+  if get(l:stack, -1) !~# '^graphql'
+    return -1
+  endif
+
   let l:line = getline(v:lnum)
 
   " If this line contains just a closing bracket, find its matching opening


### PR DESCRIPTION
When we're within a template string, it's common for the author to
indent the GraphQL syntax some level beyond the outer scope.

Attempt to honor that initial indentation by looking for the first line
of GraphQL syntax and telling vim to leave its indentation untouched
(-1). The following lines will be indentation relative to this initial
line.

Fixes #54