### PR TITLE
Use base &indentexpr for non-GraphQL indentation

### DIFF
--- a/after/indent/javascript.vim
+++ b/after/indent/javascript.vim
@@ -21,23 +21,22 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-runtime! indent/graphql.vim
-
-" Don't redefine our function and also require the standard Javascript indent
-" function to exist.
-if exists('*GetJavascriptGraphQLIndent') || !exists('*GetJavascriptIndent')
+if exists('*GetJavascriptGraphQLIndent') && !empty(&indentexpr)
   finish
 endif
 
+runtime! indent/graphql.vim
+
 " Set the indentexpr with our own version that will call GetGraphQLIndent when
-" we're inside of a GraphQL string and otherwise defer to GetJavascriptIndent.
+" we're inside of a GraphQL string and otherwise defer to the base function.
+let b:indentexpr_base = &indentexpr
 setlocal indentexpr=GetJavascriptGraphQLIndent()
 
 function GetJavascriptGraphQLIndent()
-  let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val,'name')")
-  if !empty(l:stack) && l:stack[0] ==# 'graphqlTemplateString'
+  let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val, 'name')")
+  if get(l:stack, 0) ==# 'graphqlTemplateString'
     return GetGraphQLIndent()
   endif
 
-  return GetJavascriptIndent()
+  return eval(b:indentexpr_base)
 endfunction

--- a/after/indent/typescript.vim
+++ b/after/indent/typescript.vim
@@ -21,23 +21,22 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-runtime! indent/graphql.vim
-
-" Don't redefine our function and also require the standard Typescript indent
-" function to exist.
-if exists('*GetTypescriptGraphQLIndent') || !exists('*GetTypescriptIndent')
+if exists('*GetTypescriptGraphQLIndent') && !empty(&indentexpr)
   finish
 endif
 
+runtime! indent/graphql.vim
+
 " Set the indentexpr with our own version that will call GetGraphQLIndent when
-" we're inside of a GraphQL string and otherwise defer to GetTypescriptIndent.
+" we're inside of a GraphQL string and otherwise defer to the base function.
+let b:indentexpr_base = &indentexpr
 setlocal indentexpr=GetTypescriptGraphQLIndent()
 
 function GetTypescriptGraphQLIndent()
-  let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val,'name')")
-  if !empty(l:stack) && l:stack[0] ==# 'graphqlTemplateString'
+  let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val, 'name')")
+  if get(l:stack, 0) ==# 'graphqlTemplateString'
     return GetGraphQLIndent()
   endif
 
-  return GetTypescriptIndent()
+  return eval(b:indentexpr_base)
 endfunction

--- a/test/javascript/default.vader
+++ b/test/javascript/default.vader
@@ -25,7 +25,6 @@ Execute (Syntax assertions):
 
 Execute (Indent assertions):
   Assert exists('*GetGraphQLIndent')
-  Assert exists('*GetJavascriptIndent')
   Assert exists('*GetJavascriptGraphQLIndent')
 
 Do (re-indent buffer):

--- a/test/javascript/react.vader
+++ b/test/javascript/react.vader
@@ -22,5 +22,4 @@ Execute (Syntax assertions):
 
 Execute (Indent assertions):
   Assert exists('*GetGraphQLIndent')
-  Assert exists('*GetJavascriptIndent')
   Assert exists('*GetJavascriptGraphQLIndent')

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -28,7 +28,6 @@ Execute (Syntax assertions):
 
 Execute (Indent assertions):
   Assert exists('*GetGraphQLIndent')
-  Assert exists('*GetTypescriptIndent')
   Assert exists('*GetTypescriptGraphQLIndent')
 
 Do (re-indent buffer):


### PR DESCRIPTION
Stop assuming the name of the base JavaScript or TypeScript indentation
function and instead store and use the buffer's existing &indentexpr for
non-GraphQL lines.

This should produce more correct results when other plugins are also
wrapping &indentexpr (such as vim-jsx-pretty and vim-styled-components).

Fixes #62