### PR TITLE
Add GraphQL syntax support within PHP strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,26 @@ strings using [graphql-ppx][] is available.
 
 [graphql-ppx]: https://github.com/reasonml-community/graphql-ppx
 
+## PHP Support
+
+GraphQL syntax inside of [heredoc][] and [nowdoc][] strings is supported. The
+string identifier must be named `GQL` (case-insensitive).
+
+```php
+<?php
+$my_query = <<<GQL
+{
+  user(id: ${uid}) {
+    firstName
+    lastName
+  }
+}
+GQL;
+```
+
+[heredoc]: https://www.php.net/manual/language.types.string.php#language.types.string.syntax.heredoc
+[nowdoc]: https://www.php.net/manual/language.types.string.php#language.types.string.syntax.nowdoc
+
 ## Testing
 
 The test suite uses [Vader.vim](https://github.com/junegunn/vader.vim). To run

--- a/after/indent/php.vim
+++ b/after/indent/php.vim
@@ -1,0 +1,42 @@
+" Copyright (c) 2016-2020 Jon Parise <jon@indelible.org>
+"
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the "Software"), to
+" deal in the Software without restriction, including without limitation the
+" rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+" sell copies of the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+"
+" The above copyright notice and this permission notice shall be included in
+" all copies or substantial portions of the Software.
+"
+" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+" FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+" IN THE SOFTWARE.
+"
+" Language: GraphQL
+" Maintainer: Jon Parise <jon@indelible.org>
+
+if exists('*GetPHPGraphQLIndent') && !empty(&indentexpr)
+  finish
+endif
+
+runtime! indent/graphql.vim
+
+" Set the indentexpr with our own version that will call GetGraphQLIndent when
+" we're inside of a GraphQL string and otherwise defer to the base function.
+let b:indentexpr_base = &indentexpr
+setlocal indentexpr=GetPHPGraphQLIndent()
+
+function GetPHPGraphQLIndent()
+  let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val, 'name')")
+  if get(l:stack, 0) ==# 'phpRegion' && count(l:stack, 'graphqlFold') > 0
+    return GetGraphQLIndent()
+  endif
+
+  return eval(b:indentexpr_base)
+endfunction

--- a/after/syntax/php/graphql.vim
+++ b/after/syntax/php/graphql.vim
@@ -1,0 +1,34 @@
+" Copyright (c) 2016-2020 Jon Parise <jon@indelible.org>
+"
+" Permission is hereby granted, free of charge, to any person obtaining a copy
+" of this software and associated documentation files (the "Software"), to
+" deal in the Software without restriction, including without limitation the
+" rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+" sell copies of the Software, and to permit persons to whom the Software is
+" furnished to do so, subject to the following conditions:
+"
+" The above copyright notice and this permission notice shall be included in
+" all copies or substantial portions of the Software.
+"
+" THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+" IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+" FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+" AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+" LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+" FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+" IN THE SOFTWARE.
+"
+" Language: GraphQL
+" Maintainer: Jon Parise <jon@indelible.org>
+
+if exists('b:current_syntax')
+  let s:current_syntax = b:current_syntax
+  unlet b:current_syntax
+endif
+syn include @GraphQLSyntax syntax/graphql.vim
+if exists('s:current_syntax')
+  let b:current_syntax = s:current_syntax
+endif
+
+syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@<=\(\"\=\)\z(\(\I\i*\)\=\(gql\)\c\(\i*\)\)\2$" end="^\s*\z1\>" contained contains=@GraphQLSyntax,phpIdentifier,phpIdentifierSimply,phpIdentifierComplex,phpBackslashSequences,phpMethodsVar,@Spell keepend extend
+syntax region phpNowDoc matchgroup=Delimiter start="\(<<<\)\@<='\z(\(\I\i*\)\=\(gql\)\c\(\i*\)\)'$" end="^\s*\z1\>" contained contains=@GraphQLSyntax,@Spell keepend extend

--- a/doc/graphql.txt
+++ b/doc/graphql.txt
@@ -5,6 +5,8 @@ CONTENTS                                                    *graphql-contents*
 1. Introduction         |graphql-intro|
 2. JavaScript Support   |graphql-javascript|
 3. TypeScript Support   |graphql-typescript|
+4. ReasonML Support     |graphql-reasonml|
+5. PHP Support          |graphql-php|
 
 
 INTRODUCTION                                                   *graphql-intro*
@@ -45,6 +47,11 @@ REASONML                                                    *graphql-reasonml*
 
 GraphQL syntax support inside of ReasonML template strings using graphql-ppx
 is available.
+
+PHP                                                              *graphql-php*
+
+GraphQL syntax inside of heredoc and nowdoc strings is supported. The string
+identifier must be named `GQL` (case-insensitive).
 
 ------------------------------------------------------------------------------
 vim:tw=78:ft=help:norl:

--- a/test/php/default.vader
+++ b/test/php/default.vader
@@ -1,0 +1,47 @@
+Before:
+  setlocal shiftwidth=2
+  source ../after/syntax/php/graphql.vim
+
+Given php (Heredoc):
+  <?php
+  $my_query = <<<GQL
+  {
+    user(id: ${uid}) {
+      firstName
+      lastName
+    }
+  }
+  GQL;
+
+Execute (Syntax assertions):
+  AssertEqual 'Delimiter', SyntaxOf('GQL')
+  AssertEqual 'graphqlName', SyntaxOf('user')
+
+Do (re-indent buffer):
+  gg=G
+
+Expect (properly indented):
+  <?php
+  $my_query = <<<GQL
+  {
+    user(id: ${uid}) {
+      firstName
+      lastName
+    }
+  }
+  GQL;
+
+Given php (Nowdoc):
+  <?php
+  $my_query = <<<'GQL'
+  {
+    user(id: ${uid}) {
+      firstName
+      lastName
+    }
+  }
+  GQL;
+
+Execute (Syntax assertions):
+  AssertEqual 'Delimiter', SyntaxOf('GQL')
+  AssertEqual 'graphqlName', SyntaxOf('user')


### PR DESCRIPTION
Syntax highlighting and indentation within heredoc and nowdoc strings
are supported. The string identifier must be named `GQL`.

Closes #61 