### PR TITLE
Add support for comment-based syntax tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ const query = gql`
 The list of recognized tag names is defined by the `g:graphql_javascript_tags`
 variable, which defaults to `["gql", "graphql", "Relay.QL"]`.
 
+You can also add a `# gql` comment at the start of a template string to
+indicate that its contents should be considered GraphQL syntax.
+
+```javascript
+const query = `# gql
+  {
+    user(id: ${uid}) {
+      firstName
+      lastName
+    }
+  }
+`;
+```
+
 Syntax highlighting within `.jsx` / `.tsx` files is also supported. These
 filetypes can be "compound" (`javascript.jsx` and `typescript.tsx`) or use the
 "react" variants (`javascriptreact` and `typescriptreact`).

--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -38,6 +38,8 @@ if graphql#has_syntax_group('jsTemplateExpression')
   exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
   syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=jsTemplateExpression containedin=graphqlFold keepend
 
+  syntax region graphqlTemplateString matchgroup=jsTemplateString start=+`#\s\{,4\}gql\>\s*$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend
+
   hi def link graphqlTemplateString jsTemplateString
   hi def link graphqlTaggedTemplate jsTaggedTemplate
   hi def link graphqlTemplateExpression jsTemplateExpression
@@ -49,6 +51,8 @@ elseif graphql#has_syntax_group('javaScriptStringT')
   exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend'
   exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
   syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=@javaScriptEmbededExpr containedin=graphqlFold keepend
+
+  syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+`#\s\{,4\}gql\>\s*$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend
 
   hi def link graphqlTemplateString javaScriptStringT
   hi def link graphqlTaggedTemplate javaScriptEmbed

--- a/test/javascript/default.vader
+++ b/test/javascript/default.vader
@@ -48,6 +48,19 @@ Execute (Tag names can be customized):
   source ../after/syntax/javascript/graphql.vim
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('GraphQL.Tag')
 
+Given javascript (Template literal with comment):
+  const query = `# gql
+    {
+      user(id: ${uid}) {
+        firstName
+        lastName
+      }
+    }
+  `;
+
+Execute (Syntax assertions):
+  AssertEqual 'graphqlName', SyntaxOf('user')
+
 Given javascript (Template literal):
   const s = `text`;
 


### PR DESCRIPTION
This provides a way to highlight JavaScript template strings as GraphQL
by simply adding a `# gql` comment to the start of the string.

Closes #23 