### PR TITLE
Fix GraphQL detection in 'indentexpr' functions

### DIFF
--- a/after/indent/javascript.vim
+++ b/after/indent/javascript.vim
@@ -34,7 +34,7 @@ setlocal indentexpr=GetJavascriptGraphQLIndent()
 
 function GetJavascriptGraphQLIndent()
   let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val, 'name')")
-  if get(l:stack, 0) ==# 'graphqlTemplateString'
+  if get(l:stack, 0, '') ==# 'graphqlTemplateString'
     return GetGraphQLIndent()
   endif
 

--- a/after/indent/php.vim
+++ b/after/indent/php.vim
@@ -34,7 +34,7 @@ setlocal indentexpr=GetPHPGraphQLIndent()
 
 function GetPHPGraphQLIndent()
   let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val, 'name')")
-  if get(l:stack, 0) ==# 'phpRegion' && count(l:stack, 'graphqlFold') > 0
+  if get(l:stack, 0, '') ==# 'phpRegion' && count(l:stack, 'graphqlFold') > 0
     return GetGraphQLIndent()
   endif
 

--- a/after/indent/typescript.vim
+++ b/after/indent/typescript.vim
@@ -34,7 +34,7 @@ setlocal indentexpr=GetTypescriptGraphQLIndent()
 
 function GetTypescriptGraphQLIndent()
   let l:stack = map(synstack(v:lnum, 1), "synIDattr(v:val, 'name')")
-  if get(l:stack, 0) ==# 'graphqlTemplateString'
+  if get(l:stack, 0, '') ==# 'graphqlTemplateString'
     return GetGraphQLIndent()
   endif
 


### PR DESCRIPTION
Vimscript evaluates the expression `0 ==# "Foo` as truthy, which breaks
chaining to the base 'indentexpr' function for non-GraphQL lines.

Fix this by specifying an explicit default value (empty string).