### PR TITLE
Removes sync minlines from syntax file

### DIFF
--- a/syntax/graphql.vim
+++ b/syntax/graphql.vim
@@ -90,6 +90,4 @@ hi def link graphqlStructure        Structure
 hi def link graphqlType             Type
 hi def link graphqlVariable         Identifier
 
-syn sync minlines=500
-
 let b:current_syntax = 'graphql'


### PR DESCRIPTION
This setting breaks the syntax coloring in large PHP files for me. It's run via `after/syntax/php/graphql.vim` so due to similar files for other languages those might be affected as well (I have tested only PHP).

I'm not totally sure if `ftplugin/graphql.vim` might be a better place to set the value or if it shouldn't be overwritten at all.

At least I can say that setting the value inside the syntax file can cause a problem:

Steps to reproduce:
1. Open a large PHP file, e.g. https://raw.githubusercontent.com/WordPress/WordPress/master/wp-includes/ID3/getid3.lib.php
2. Jump to Line 1000 with `:1000<cr>`
3. The syntax coloring is broken


