### PR TITLE
Add graphqlTemplateString to jsExpression cluster

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -48,7 +48,7 @@ if graphql#has_syntax_group('jsTemplateExpression')
   hi def link graphqlTaggedTemplate jsTaggedTemplate
   hi def link graphqlTemplateExpression jsTemplateExpression
 
-  syn cluster jsExpression add=graphqlTaggedTemplate
+  syn cluster jsExpression add=graphqlTemplateString,graphqlTaggedTemplate
   syn cluster graphqlTaggedTemplate add=graphqlTemplateString
 elseif graphql#has_syntax_group('javaScriptStringT')
   " runtime/syntax/javascript.vim


### PR DESCRIPTION
For [pangloss/vim-javascript](https://github.com/pangloss/vim-javascript), we need to add `graphqlTemplateString` to the
`jsExpression` cluster. This fixes comment-based syntax tagging when this
JavaScript plugin is used.

Fixes #74 