### PR TITLE
Rework reason syntax highlighting

### DIFF
--- a/after/syntax/reason/graphql.vim
+++ b/after/syntax/reason/graphql.vim
@@ -34,4 +34,5 @@ if exists('s:current_syntax')
   let b:current_syntax = s:current_syntax
 endif
 
-syntax region graphqlExtensionPoint matchgroup=Noise start=+\[%graphql\_s*{|+lc=10 end=+|}\_s*]+he=s+1 contains=@GraphQLSyntax keepend
+syntax region graphqlExtensionPoint start=+\[%graphql+ end=+\]+ contains=graphqlExtensionPointS
+syntax region graphqlExtensionPointS matchgroup=String start=+{|+ end=+|}+ contains=@GraphQLSyntax contained

--- a/test/reason/default.vader
+++ b/test/reason/default.vader
@@ -12,4 +12,5 @@ Given reason (Template):
   |}];
 
 Execute (Syntax assertions):
+  AssertEqual 'graphqlExtensionPoint', SyntaxOf('%graphql')
   AssertEqual 'graphqlName', SyntaxOf('user')


### PR DESCRIPTION
Use two regions to represent the extension point that wraps an embedded
GraphQL string:

- `graphqlExtensionPoint` represents the outer extension point
- `graphqlExtensionPointS` represents the inner multi-line string that
  contains the GraphQL syntax

The previous approach was finicky due to the character-wise offsets I
was using, which proved overly tricky and error prone.

Fixes #76