### PR TITLE
Add #gql,#graphql comment support for typescript

### DIFF
--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -42,6 +42,15 @@ exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlT
 " Support expression interpolation ((${...})) inside template strings.
 syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=typescriptTemplateSubstitution containedin=graphqlFold keepend
 
+" support #graphql , #gql comment strings
+syntax region graphqlTemplateString
+      \ start=+`\(#\s\{,4\}\(gql\|graphql\)\)\@=+
+      \ skip=+\\\\\|\\`+
+      \ end=+`+me=s-1
+      \ containedin=typescriptTemplate
+      \ contained
+      \ contains=@GraphQLSyntax,typescriptTemplateSubstitution extend
+
 hi def link graphqlTemplateString typescriptTemplate
 hi def link graphqlTemplateExpression typescriptTemplateSubstitution
 

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -51,8 +51,35 @@ Execute (Tag names can be customized):
   source ../after/syntax/typescript/graphql.vim
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('GraphQL.Tag')
 
+
 Given typescript (Template literal):
   const s = `text`;
 
 Execute (Untagged template literals aren't matched ):
   AssertNotEqual 'graphqlTemplateString', SyntaxOf('`')
+
+Given typescript (Template literal with `# gql` comment):
+  const query = `# gql
+    {
+      user(id: ${uid}) {
+        firstName
+        lastName
+      }
+    }
+  `;
+
+Execute (Syntax assertions):
+  AssertEqual 'graphqlName', SyntaxOf('user')
+
+Given typescript (Template literal with `# graphql` comment):
+  const query = `# graphql
+    {
+      user(id: ${uid}) {
+        firstName
+        lastName
+      }
+    }
+  `;
+
+Execute (Syntax assertions):
+  AssertEqual 'graphqlName', SyntaxOf('user')


### PR DESCRIPTION
Added \#gql \#graphql comment support to typescript syntax files

Addresses #82 