### PR TITLE
Add support for `%relay` within Reason syntax

### DIFF
--- a/after/syntax/reason/graphql.vim
+++ b/after/syntax/reason/graphql.vim
@@ -35,4 +35,5 @@ if exists('s:current_syntax')
 endif
 
 syntax region graphqlExtensionPoint start=+\[%graphql+ end=+\]+ contains=graphqlExtensionPointS
+syntax region graphqlExtensionPoint start=+\[%relay+ end=+\]+ contains=graphqlExtensionPointS
 syntax region graphqlExtensionPointS matchgroup=String start=+{|+ end=+|}+ contains=@GraphQLSyntax contained


### PR DESCRIPTION
This is used by https://rescript-relay-documentation.vercel.app/docs/making-queries