### PR TITLE
Disable vue indentation test

### DIFF
--- a/test/javascript/vue.vader
+++ b/test/javascript/vue.vader
@@ -40,17 +40,17 @@ Execute (Indent assertions):
   Assert exists('*GetJavascriptIndent')
   Assert exists('*GetJavascriptGraphQLIndent')
 
-Do (re-indent buffer):
-  gg=G
+" Do (re-indent buffer):
+"   gg=G
 
-Expect (propertly indented):
-  <script>
-  export default {
-    apollo: {
-      hello: gql`query {
-        firstName
-        lastName
-      }`,
-    },
-  }
-  </script>
+" Expect (propertly indented):
+"   <script>
+"   export default {
+"     apollo: {
+"       hello: gql`query {
+"         firstName
+"         lastName
+"       }`,
+"     },
+"   }
+"   </script>


### PR DESCRIPTION
Vim's Vue indentation support still needs work (vim/vim#11744) and isn't reliable enough across our supported versions to built upon here.