### PR TITLE
Indent the first line within a template string

### DIFF
--- a/indent/graphql.vim
+++ b/indent/graphql.vim
@@ -60,11 +60,11 @@ function GetGraphQLIndent()
     return 0
   endif
 
-  " If the previous line isn't GraphQL, don't change this line's indentation.
-  " Assume we've been manually indented as part of a template string.
+  " If the previous line isn't GraphQL, assume we're part of a template
+  " string and indent this new line within it.
   let l:stack = map(synstack(l:prevlnum, 1), "synIDattr(v:val, 'name')")
   if get(l:stack, -1) !~# '^graphql'
-    return -1
+    return indent(l:prevlnum) + shiftwidth()
   endif
 
   let l:line = getline(v:lnum)


### PR DESCRIPTION
If the previous line isn't GraphQL, assume we're part of a template string and indent this new line within it.

This is (hopefully) an improvement over the previous behavior which preserved the indentation of the previous line in these cases.

Closes #87