### PR TITLE
Add support for b:graphql_javascript_tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ const query = gql`
 ```
 
 The list of recognized tag names is defined by the `g:graphql_javascript_tags`
-variable, which defaults to `["gql", "graphql", "Relay.QL"]`.
+variable, which defaults to `["gql", "graphql", "Relay.QL"]`. This can also
+be set on a per-buffer basis using `b:graphql_javascript_tags`.
 
 You can also add a `# gql` or `# graphql` comment at the start of a template
 string to indicate that its contents should be considered GraphQL syntax.

--- a/autoload/graphql.vim
+++ b/autoload/graphql.vim
@@ -21,6 +21,12 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
+" Look up the named variable in buffer scope and then in global scope.
+" Returns default if the named variable can't be found in either.
+function! graphql#var(name, default) abort
+  return get(b:, a:name, get(g:, a:name, a:default))
+endfunction
+
 function! graphql#has_syntax_group(group) abort
   try
     silent execute 'silent highlight ' . a:group
@@ -31,5 +37,5 @@ function! graphql#has_syntax_group(group) abort
 endfunction
 
 function! graphql#javascript_tags() abort
-  return get(g:, 'graphql_javascript_tags', ['gql', 'graphql', 'Relay.QL'])
+  return graphql#var('graphql_javascript_tags', ['gql', 'graphql', 'Relay.QL'])
 endfunction

--- a/doc/graphql.txt
+++ b/doc/graphql.txt
@@ -26,6 +26,7 @@ supported.
                                                   *graphql-javascript-options*
 
                                                    *g:graphql_javascript_tags*
+                                                   *b:graphql_javascript_tags*
 |g:graphql_javascript_tags|                                    list of strings
 
   Default: `["gql", "graphql", "Relay.QL"]`

--- a/test/var.vader
+++ b/test/var.vader
@@ -1,0 +1,17 @@
+Before:
+  let g:graphql_some_variable = 'abc'
+
+After:
+  unlet! g:graphql_some_variable
+  unlet! b:undefined_variable_name
+
+Execute(graphql#var should return global variables):
+  AssertEqual 'abc', graphql#var('graphql_some_variable', '')
+
+Execute(graphql#var should return buffer overrides):
+  let b:graphql_some_variable = 'def'
+
+  AssertEqual 'def', graphql#var('graphql_some_variable', '')
+
+Execute(graphql#var should return default value for undefined variables):
+  AssertEqual 'default', graphql#var('undefined_variable_name', 'default')


### PR DESCRIPTION
This allows buffer-level JavaScript tag values, avoiding the need to modify the global namespace for more granular configurations.

This also introduces graphql#var() as a convenience function to perform this kind of tiered variable look-up.