### PR TITLE
Use main_syntax variable to detect embedded syntax

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -21,18 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-if exists('b:current_syntax')
-  let s:current_syntax = b:current_syntax
-  unlet b:current_syntax
-endif
-
-let b:graphql_nested_syntax = 1
-syn include @GraphQLSyntax syntax/graphql.vim
-unlet b:graphql_nested_syntax
-
-if exists('s:current_syntax')
-  let b:current_syntax = s:current_syntax
-endif
+call graphql#embed_syntax('GraphQLSyntax')
 
 let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
 

--- a/after/syntax/php/graphql.vim
+++ b/after/syntax/php/graphql.vim
@@ -21,18 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-if exists('b:current_syntax')
-  let s:current_syntax = b:current_syntax
-  unlet b:current_syntax
-endif
-
-let b:graphql_nested_syntax = 1
-syn include @GraphQLSyntax syntax/graphql.vim
-unlet b:graphql_nested_syntax
-
-if exists('s:current_syntax')
-  let b:current_syntax = s:current_syntax
-endif
+call graphql#embed_syntax('GraphQLSyntax')
 
 syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@<=\(\"\=\)\z(\(\I\i*\)\=\(gql\)\c\(\i*\)\)\2$" end="^\s*\z1\>" contained contains=@GraphQLSyntax,phpIdentifier,phpIdentifierSimply,phpIdentifierComplex,phpBackslashSequences,phpMethodsVar,@Spell keepend extend
 syntax region phpNowDoc matchgroup=Delimiter start="\(<<<\)\@<='\z(\(\I\i*\)\=\(gql\)\c\(\i*\)\)'$" end="^\s*\z1\>" contained contains=@GraphQLSyntax,@Spell keepend extend

--- a/after/syntax/reason/graphql.vim
+++ b/after/syntax/reason/graphql.vim
@@ -21,18 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-if exists('b:current_syntax')
-  let s:current_syntax = b:current_syntax
-  unlet b:current_syntax
-endif
-
-let b:graphql_nested_syntax = 1
-syn include @GraphQLSyntax syntax/graphql.vim
-unlet b:graphql_nested_syntax
-
-if exists('s:current_syntax')
-  let b:current_syntax = s:current_syntax
-endif
+call graphql#embed_syntax('GraphQLSyntax')
 
 syntax region graphqlExtensionPoint start=+\[%\(graphql\|relay\)+ end=+\]+ contains=graphqlExtensionPointS
 syntax region graphqlExtensionPointS matchgroup=String start=+{|+ end=+|}+ contains=@GraphQLSyntax contained

--- a/after/syntax/rescript/graphql.vim
+++ b/after/syntax/rescript/graphql.vim
@@ -21,18 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-if exists('b:current_syntax')
-  let s:current_syntax = b:current_syntax
-  unlet b:current_syntax
-endif
-
-let b:graphql_nested_syntax = 1
-syn include @GraphQLSyntax syntax/graphql.vim
-unlet b:graphql_nested_syntax
-
-if exists('s:current_syntax')
-  let b:current_syntax = s:current_syntax
-endif
+call graphql#embed_syntax('GraphQLSyntax')
 
 syntax region graphqlExtensionPoint start=+%\(graphql\|relay\)(+ end=+)+ contains=graphqlExtensionPointS
 syntax region graphqlExtensionPointS matchgroup=String start=+`+ end=+`+ contains=@GraphQLSyntax contained

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -21,18 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-if exists('b:current_syntax')
-  let s:current_syntax = b:current_syntax
-  unlet b:current_syntax
-endif
-
-let b:graphql_nested_syntax = 1
-syn include @GraphQLSyntax syntax/graphql.vim
-unlet b:graphql_nested_syntax
-
-if exists('s:current_syntax')
-  let b:current_syntax = s:current_syntax
-endif
+call graphql#embed_syntax('GraphQLSyntax')
 
 let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
 

--- a/autoload/graphql.vim
+++ b/autoload/graphql.vim
@@ -27,6 +27,30 @@ function! graphql#var(name, default) abort
   return get(b:, a:name, get(g:, a:name, a:default))
 endfunction
 
+" Embed our GraphQL syntax and make the result available as a group.
+function! graphql#embed_syntax(group) abort
+  let l:saved_current_syntax = get(b:, 'current_syntax', '')
+  let l:saved_main_syntax = get(g:, 'main_syntax', '')
+
+  " Temporarily promote the current (outer) syntax to the "main" syntax.
+  " Our syntax file uses this information to know when it's being embedded.
+  let main_syntax = l:saved_current_syntax
+  unlet! b:current_syntax
+
+  " Include our syntax file and make its top-level items available as `@group`.
+  exec 'syn include @' . a:group . ' syntax/graphql.vim'
+
+  " Restore the previous syntax state.
+  if l:saved_current_syntax !=# ''
+    let b:current_syntax = l:saved_current_syntax
+  endif
+  if l:saved_main_syntax !=# ''
+    let main_syntax = l:saved_main_syntax
+  else
+    unlet! main_syntax
+  endif
+endfunction
+
 function! graphql#has_syntax_group(group) abort
   try
     silent execute 'silent highlight ' . a:group

--- a/syntax/graphql.vim
+++ b/syntax/graphql.vim
@@ -21,8 +21,11 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-if exists('b:current_syntax')
-  finish
+if !exists('main_syntax')
+  if exists('b:current_syntax')
+    finish
+  endif
+  let main_syntax = 'graphql'
 endif
 
 syn case match
@@ -72,6 +75,10 @@ syn keyword graphqlMetaFields __schema __type __typename
 syn region  graphqlFold matchgroup=graphqlBraces start="{" end="}" transparent fold contains=ALLBUT,graphqlStructure
 syn region  graphqlList matchgroup=graphqlBraces start="\[" end="]" transparent contains=ALLBUT,graphqlDirective,graphqlStructure
 
+if main_syntax ==# 'graphql'
+  syn sync minlines=500
+endif
+
 hi def link graphqlComment          Comment
 hi def link graphqlOperator         Operator
 
@@ -91,8 +98,8 @@ hi def link graphqlStructure        Structure
 hi def link graphqlType             Type
 hi def link graphqlVariable         Identifier
 
-if !get(b:, 'graphql_nested_syntax')
-    syn sync minlines=500
-endif
-
 let b:current_syntax = 'graphql'
+
+if main_syntax ==# 'graphql'
+  unlet main_syntax
+endif

--- a/test/javascript/default.vader
+++ b/test/javascript/default.vader
@@ -19,6 +19,7 @@ Given javascript (Template):
   `;
 
 Execute (Syntax assertions):
+  AssertEqual 'javascript', b:current_syntax
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
   AssertEqual 'graphqlTemplateExpression', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
@@ -51,6 +52,7 @@ Given javascript (Template literal with `# gql` comment):
   `;
 
 Execute (Syntax assertions):
+  AssertEqual 'javascript', b:current_syntax
   AssertEqual 'graphqlName', SyntaxOf('user')
 
 Given javascript (Template literal with `# graphql` comment):
@@ -64,6 +66,7 @@ Given javascript (Template literal with `# graphql` comment):
   `;
 
 Execute (Syntax assertions):
+  AssertEqual 'javascript', b:current_syntax
   AssertEqual 'graphqlName', SyntaxOf('user')
 
 Given javascript (Template literal):

--- a/test/javascript/react.vader
+++ b/test/javascript/react.vader
@@ -10,6 +10,7 @@ Given javascriptreact (Template):
   const query = gql`{}`;
 
 Execute (Syntax assertions):
+  AssertEqual 'javascript', b:current_syntax
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
   AssertEqual 'graphqlBraces', SyntaxOf('{}')
 
@@ -17,6 +18,7 @@ Given javascript.jsx (Template):
   const query = gql`{}`;
 
 Execute (Syntax assertions):
+  AssertEqual 'javascript', b:current_syntax
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
   AssertEqual 'graphqlBraces', SyntaxOf('{}')
 

--- a/test/javascript/vue.vader
+++ b/test/javascript/vue.vader
@@ -32,6 +32,7 @@ Given vue (Template):
   </script>
 
 Execute (Syntax assertions):
+  AssertEqual 'html', b:current_syntax
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
   AssertEqual 'graphqlStructure', SyntaxOf('query')
 

--- a/test/php/default.vader
+++ b/test/php/default.vader
@@ -14,6 +14,7 @@ Given php (Heredoc):
   GQL;
 
 Execute (Syntax assertions):
+  AssertEqual 'php', b:current_syntax
   AssertEqual 'Delimiter', SyntaxOf('GQL')
   AssertEqual 'graphqlName', SyntaxOf('user')
 
@@ -43,10 +44,6 @@ Given php (Nowdoc):
   GQL;
 
 Execute (Syntax assertions):
+  AssertEqual 'php', b:current_syntax
   AssertEqual 'Delimiter', SyntaxOf('GQL')
   AssertEqual 'graphqlName', SyntaxOf('user')
-
-Execute (Settings assertions):
-  redir @a | syntax sync | redir END
-  let match = match(@a, 'syncing starts 500 lines before top line') >= 0
-  Assert !match, "'syntax sync minlines' was changed in outer syntax"

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -116,6 +116,7 @@ Given graphql (Schema):
   }
 
 Execute (Schema assertions):
+  AssertEqual 'graphql', b:current_syntax
   AssertEqual 'graphqlStructure', SyntaxOf('schema')
   AssertEqual 'graphqlName', SyntaxOf('query')
   AssertEqual 'graphqlType', SyntaxOf('QueryType')

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -22,6 +22,7 @@ Given typescript (Template):
   `;
 
 Execute (Syntax assertions):
+  AssertEqual 'typescript', b:current_syntax
   AssertEqual 'graphqlTaggedTemplate', SyntaxOf('gql')
   AssertEqual 'typescriptTemplateSB', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
@@ -82,4 +83,5 @@ Given typescript (Template literal with `# graphql` comment):
   `;
 
 Execute (Syntax assertions):
+  AssertEqual 'typescript', b:current_syntax
   AssertEqual 'graphqlName', SyntaxOf('user')


### PR DESCRIPTION
Our syntax file can be loaded in two ways: as a top-level syntax (e.g. when we're in a 'graphql' buffer) and embedded within an outer ("main") syntax (e.g. within a 'javascript' buffer).

The syntax file has some conditional behavior when it's embedded (such as _not_ setting `syn sync`), to avoid infecting the outer context.

We were previously using a custom b:graphql_nested_syntax variable to differentiate these cases. There is a more "standard" convention for this that uses a main_syntax global variable, so this change switches the code to use that approach instead.

This adds some additional housekeeping steps to our embedding procedure, so this change also introduces a graphql#embed_syntax() helper function that we now use in all of our filetype-specific syntax extension files.