### PR TITLE
Upgrade to vint 0.4a3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==71.0.1
-vim-vint==0.3.21
+setuptools==72.1.0
+vim-vint==0.4a3


### PR DESCRIPTION
This is the latest tagged pre-release version. It contains a few bug fixes, such as support for the `..` string concatenation operation.