### PR TITLE
Match JavaScript functions using dedicated regions

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -23,16 +23,18 @@
 
 call graphql#embed_syntax('GraphQLSyntax')
 
-let s:functions = map(copy(graphql#javascript_functions()), 'v:val .. "("')
-let s:tags = '\%(' . join(graphql#javascript_tags() + s:functions, '\|') . '\)'
+let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
+let s:functions = '\%(' . join(graphql#javascript_functions(), '\|') . '\)'
 
 if graphql#has_syntax_group('jsTemplateExpression')
   " pangloss/vim-javascript
   exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
   exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
-  syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=jsTemplateExpression containedin=graphqlFold keepend
+
+  exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString start=+\(' . s:functions . '\s*(\)\@<=`$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
 
   syntax region graphqlTemplateString matchgroup=jsTemplateString start=+`#\s\{,4\}\(gql\|graphql\)\>\s*$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend
+  syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=jsTemplateExpression containedin=graphqlFold keepend
 
   hi def link graphqlTemplateString jsTemplateString
   hi def link graphqlTaggedTemplate jsTaggedTemplate
@@ -44,9 +46,11 @@ elseif graphql#has_syntax_group('javaScriptStringT')
   " runtime/syntax/javascript.vim
   exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend'
   exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
-  syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=@javaScriptEmbededExpr containedin=graphqlFold keepend
+
+  exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+\(' . s:functions . '\s*(\)\@<=`$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend'
 
   syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+`#\s\{,4\}\(gql\|graphql\)\>\s*$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend
+  syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=@javaScriptEmbededExpr containedin=graphqlFold keepend
 
   hi def link graphqlTemplateString javaScriptStringT
   hi def link graphqlTaggedTemplate javaScriptEmbed

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -23,11 +23,12 @@
 
 call graphql#embed_syntax('GraphQLSyntax')
 
-let s:functions = map(copy(graphql#javascript_functions()), 'v:val .. "("')
-let s:tags = '\%(' . join(graphql#javascript_tags() + s:functions, '\|') . '\)'
+let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
+let s:functions = '\%(' . join(graphql#javascript_functions(), '\|') . '\)'
 
 exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution extend'
 exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
+exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+\(' . s:functions . '\s*(\)\@<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution containedin=typescriptFuncCallArg extend'
 
 " Support expression interpolation ((${...})) inside template strings.
 syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=typescriptTemplateSubstitution containedin=graphqlFold keepend

--- a/test/javascript/default.vader
+++ b/test/javascript/default.vader
@@ -82,6 +82,7 @@ Given javascript (Template literal with a graphql() function):
 
 Execute (Syntax assertions):
   AssertEqual 'javascript', b:current_syntax
+  AssertEqual 'graphqlTemplateExpression', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
 
 Given javascript (Template literal):

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -99,4 +99,6 @@ Given typescript (Template literal with a graphql() function):
 
 Execute (Syntax assertions):
   AssertEqual 'typescript', b:current_syntax
+  AssertEqual 'typescriptTemplate', SyntaxOf('`')
+  AssertEqual 'typescriptTemplateSB', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')


### PR DESCRIPTION
Our previous function-matching approach (#109) was implemented on top of
the existing tag-matching patterns. This had the downside of including
the function name and initial parenthesis in the region match.

Instead, use dedicated syntax regions to specifically match the string
template argument passed to our named GraphQL-aware functions for both
JavaScript and TypeScript.