### PR TITLE
Small improvements to the function region patterns

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -31,7 +31,7 @@ if graphql#has_syntax_group('jsTemplateExpression')
   exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
   exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
 
-  exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString start=+\(' . s:functions . '\s*(\)\@<=`$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
+  exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString start=+\%(' . s:functions . '\s*(\)\@40<=`$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
 
   syntax region graphqlTemplateString matchgroup=jsTemplateString start=+`#\s\{,4\}\(gql\|graphql\)\>\s*$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend
   syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=jsTemplateExpression containedin=graphqlFold keepend
@@ -47,7 +47,7 @@ elseif graphql#has_syntax_group('javaScriptStringT')
   exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend'
   exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
 
-  exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+\(' . s:functions . '\s*(\)\@<=`$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend'
+  exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+\%(' . s:functions . '\s*(\)\@40<=`$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend'
 
   syntax region graphqlTemplateString matchgroup=javaScriptStringT start=+`#\s\{,4\}\(gql\|graphql\)\>\s*$+ skip=+\\\\\|\\`+ end=+`+ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc extend
   syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=@javaScriptEmbededExpr containedin=graphqlFold keepend

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -28,7 +28,7 @@ let s:functions = '\%(' . join(graphql#javascript_functions(), '\|') . '\)'
 
 exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution extend'
 exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
-exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+\(' . s:functions . '\s*(\)\@<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution containedin=typescriptFuncCallArg extend'
+exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+\%(' . s:functions . '\s*(\)\@40<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution containedin=typescriptFuncCallArg extend'
 
 " Support expression interpolation ((${...})) inside template strings.
 syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=typescriptTemplateSubstitution containedin=graphqlFold keepend


### PR DESCRIPTION
- Use `\%(\)` to define a group with counting it as a sub-expression.
- Limit the function name look back to 40 bytes to improve performance. If this ends up being too small, we can always increase this later or compute it based on the contents of 'graphql_javascript_functions'.