### PR TITLE
Use hlexists() for syntax group detection

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -54,7 +54,7 @@ syn cluster javaScriptEmbededExpr add=graphqlTaggedTemplate
 syn cluster graphqlTaggedTemplate add=graphqlTemplateString
 
 " pangloss/vim-javascript
-if graphql#has_syntax_group('jsTemplateString')
+if hlexists('jsTemplateString')
   exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString '
         \ 'start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ '
         \ 'contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'

--- a/autoload/graphql.vim
+++ b/autoload/graphql.vim
@@ -51,15 +51,6 @@ function! graphql#embed_syntax(group) abort
   endif
 endfunction
 
-function! graphql#has_syntax_group(group) abort
-  try
-    silent execute 'silent highlight ' . a:group
-  catch
-    return v:false
-  endtry
-  return v:true
-endfunction
-
 function! graphql#javascript_functions() abort
   return graphql#var('graphql_javascript_functions', ['graphql'])
 endfunction

--- a/test/javascript/react.vader
+++ b/test/javascript/react.vader
@@ -3,8 +3,8 @@ Before:
   source ../after/syntax/javascriptreact/graphql.vim
 
 Execute (Expected syntax groups):
-  Assert graphql#has_syntax_group('graphqlTemplateExpression')
-  Assert graphql#has_syntax_group('graphqlTemplateString')
+  Assert hlexists('graphqlTemplateExpression')
+  Assert hlexists('graphqlTemplateString')
 
 Given javascriptreact (Template):
   const query = gql`{}`;

--- a/test/javascript/vim-javascript.vader
+++ b/test/javascript/vim-javascript.vader
@@ -12,6 +12,6 @@ After:
   syntax enable
 
 Execute (Expected syntax groups):
-  Assert graphql#has_syntax_group('jsTemplateExpression')
+  Assert hlexists('jsTemplateExpression')
 
 Include: default.vader

--- a/test/javascript/vue.vader
+++ b/test/javascript/vue.vader
@@ -16,8 +16,8 @@ After:
   syntax enable
 
 Execute (Expected syntax groups):
-  Assert graphql#has_syntax_group('graphqlTemplateExpression')
-  Assert graphql#has_syntax_group('graphqlTemplateString')
+  Assert hlexists('graphqlTemplateExpression')
+  Assert hlexists('graphqlTemplateString')
 
 Given vue (Template):
   <script>

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -10,7 +10,7 @@ After:
   Restore
 
 Execute (Expected syntax groups):
-  Assert graphql#has_syntax_group('typescriptTemplate')
+  Assert hlexists('typescriptTemplate')
 
 Given typescript (Template):
   const query = gql`

--- a/test/typescript/react.vader
+++ b/test/typescript/react.vader
@@ -2,8 +2,8 @@ Before:
   source ../after/syntax/typescriptreact/graphql.vim
 
 Execute (Expected syntax groups):
-  Assert graphql#has_syntax_group('graphqlTemplateExpression')
-  Assert graphql#has_syntax_group('graphqlTemplateString')
+  Assert hlexists('graphqlTemplateExpression')
+  Assert hlexists('graphqlTemplateString')
 
 Given typescriptreact (Template):
   const query = gql`{}`;


### PR DESCRIPTION
This built-in function has been available since vim 5 (and was even available as highlight_exists() before that).