### PR TITLE
Update reference specification to September 2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GraphQL for Vim
 
 This Vim plugin provides [GraphQL](https://graphql.org/) file detection, syntax
-highlighting, and indentation. It currently targets the [October 2021
-Edition](https://spec.graphql.org/October2021/) of the GraphQL specification.
+highlighting, and indentation. It currently targets the [September 2025
+Edition](https://spec.graphql.org/September2025/) of the GraphQL specification.
 
 The core runtime files are also included with Vim 9.1.0955+. They provide the
 foundational support (ftplugin, indent, syntax) for the `graphql` filetype.

--- a/syntax/graphql.vim
+++ b/syntax/graphql.vim
@@ -60,11 +60,11 @@ syn match graphqlVariable   "\<\$\h\w*\>"  display
 syn match graphqlName       "\<\h\w*\>"    display
 syn match graphqlType       "\<_*\u\w*\>"  display
 
-" https://spec.graphql.org/October2021/#ExecutableDirectiveLocation
+" https://spec.graphql.org/September2025/#ExecutableDirectiveLocation
 syn keyword graphqlDirectiveLocation QUERY MUTATION SUBSCRIPTION FIELD
 syn keyword graphqlDirectiveLocation FRAGMENT_DEFINITION FRAGMENT_SPREAD
 syn keyword graphqlDirectiveLocation INLINE_FRAGMENT VARIABLE_DEFINITION
-" https://spec.graphql.org/October2021/#TypeSystemDirectiveLocation
+" https://spec.graphql.org/September2025/#TypeSystemDirectiveLocation
 syn keyword graphqlDirectiveLocation SCHEMA SCALAR OBJECT FIELD_DEFINITION
 syn keyword graphqlDirectiveLocation ARGUMENT_DEFINITION INTERFACE UNION
 syn keyword graphqlDirectiveLocation ENUM ENUM_VALUE INPUT_OBJECT


### PR DESCRIPTION
As best as I can tell, there aren't any syntax-related changes that we need to incorporate, so just bump the reference specification links.

- https://spec.graphql.org/September2025/
- https://github.com/graphql/graphql-spec/releases/tag/September2025