### PR TITLE
Prefix included GraphQL syntax group names

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -21,7 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-call graphql#embed_syntax('GraphQLSyntax')
+call graphql#embed_syntax('javaScriptGraphQL')
 
 let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
 let s:functions = '\%(' . join(graphql#javascript_functions(), '\|') . '\)'
@@ -30,15 +30,15 @@ exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ '
       \ 'nextgroup=graphqlTemplateString'
 exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT '
       \ 'start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ '
-      \ 'contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc '
+      \ 'contains=@javaScriptGraphQL,javaScriptSpecial,javaScriptEmbed,@htmlPreproc '
       \ 'extend'
 exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT '
       \ 'start=+\%(' . s:functions . '\s*(\)\@40<=`+ skip=+\\\\\|\\`+ end=+`+ '
-      \ 'contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc '
+      \ 'contains=@javaScriptGraphQL,javaScriptSpecial,javaScriptEmbed,@htmlPreproc '
       \ 'extend'
 syntax region graphqlTemplateString matchgroup=javaScriptStringT
       \ start=+`#\s\{,4\}\(gql\|graphql\)\>\s*$+ skip=+\\\\\|\\`+ end=+`+
-      \ contains=@GraphQLSyntax,javaScriptSpecial,javaScriptEmbed,@htmlPreproc
+      \ contains=@javaScriptGraphQL,javaScriptSpecial,javaScriptEmbed,@htmlPreproc
       \ extend
 syntax region graphqlTemplateExpression 
       \ start=+${+ end=+}+
@@ -57,13 +57,13 @@ syn cluster graphqlTaggedTemplate add=graphqlTemplateString
 if hlexists('jsTemplateString')
   exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString '
         \ 'start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ '
-        \ 'contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
+        \ 'contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial extend'
   exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString '
         \ 'start=+\%(' . s:functions . '\s*(\)\@40<=`+ skip=+\\`+ end=+`+ '
-        \ 'contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend'
+        \ 'contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial extend'
   syntax region graphqlTemplateString matchgroup=jsTemplateString
         \ start=+`#\s\{,4\}\(gql\|graphql\)\>\s*$+ skip=+\\`+ end=+`+
-        \ contains=@GraphQLSyntax,jsTemplateExpression,jsSpecial extend
+        \ contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial extend
   syntax region graphqlTemplateExpression
         \ start=+${+ end=+}+
         \ contains=jsTemplateExpression contained containedin=graphqlFold

--- a/after/syntax/php/graphql.vim
+++ b/after/syntax/php/graphql.vim
@@ -21,7 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-call graphql#embed_syntax('GraphQLSyntax')
+call graphql#embed_syntax('phpGraphQL')
 
-syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@<=\(\"\=\)\z(\(\I\i*\)\=\(gql\)\c\(\i*\)\)\2$" end="^\s*\z1\>" contained contains=@GraphQLSyntax,phpIdentifier,phpIdentifierSimply,phpIdentifierComplex,phpBackslashSequences,phpMethodsVar,@Spell keepend extend
-syntax region phpNowDoc matchgroup=Delimiter start="\(<<<\)\@<='\z(\(\I\i*\)\=\(gql\)\c\(\i*\)\)'$" end="^\s*\z1\>" contained contains=@GraphQLSyntax,@Spell keepend extend
+syn region phpHereDoc matchgroup=Delimiter start="\(<<<\)\@<=\(\"\=\)\z(\(\I\i*\)\=\(gql\)\c\(\i*\)\)\2$" end="^\s*\z1\>" contained contains=@phpGraphQL,phpIdentifier,phpIdentifierSimply,phpIdentifierComplex,phpBackslashSequences,phpMethodsVar,@Spell keepend extend
+syntax region phpNowDoc matchgroup=Delimiter start="\(<<<\)\@<='\z(\(\I\i*\)\=\(gql\)\c\(\i*\)\)'$" end="^\s*\z1\>" contained contains=@phpGraphQL,@Spell keepend extend

--- a/after/syntax/reason/graphql.vim
+++ b/after/syntax/reason/graphql.vim
@@ -21,7 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-call graphql#embed_syntax('GraphQLSyntax')
+call graphql#embed_syntax('reasonGraphQL')
 
 syntax region graphqlExtensionPoint start=+\[%\(graphql\|relay\)+ end=+\]+ contains=graphqlExtensionPointS
-syntax region graphqlExtensionPointS matchgroup=String start=+{|+ end=+|}+ contains=@GraphQLSyntax contained
+syntax region graphqlExtensionPointS matchgroup=String start=+{|+ end=+|}+ contains=@reasonGraphQL contained

--- a/after/syntax/rescript/graphql.vim
+++ b/after/syntax/rescript/graphql.vim
@@ -21,7 +21,7 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-call graphql#embed_syntax('GraphQLSyntax')
+call graphql#embed_syntax('resGraphQL')
 
 syntax region graphqlExtensionPoint start=+%\(graphql\|relay\)(+ end=+)+ contains=graphqlExtensionPointS
-syntax region graphqlExtensionPointS matchgroup=String start=+`+ end=+`+ contains=@GraphQLSyntax contained
+syntax region graphqlExtensionPointS matchgroup=String start=+`+ end=+`+ contains=@resGraphQL contained

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -21,14 +21,14 @@
 " Language: GraphQL
 " Maintainer: Jon Parise <jon@indelible.org>
 
-call graphql#embed_syntax('GraphQLSyntax')
+call graphql#embed_syntax('typescriptGraphQL')
 
 let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
 let s:functions = '\%(' . join(graphql#javascript_functions(), '\|') . '\)'
 
-exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution extend'
+exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@typescriptGraphQL,typescriptTemplateSubstitution extend'
 exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
-exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+\%(' . s:functions . '\s*(\)\@40<=`+ skip=+\\`+ end=+`+ contains=@GraphQLSyntax,typescriptTemplateSubstitution containedin=typescriptFuncCallArg extend'
+exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+\%(' . s:functions . '\s*(\)\@40<=`+ skip=+\\`+ end=+`+ contains=@typescriptGraphQL,typescriptTemplateSubstitution containedin=typescriptFuncCallArg extend'
 
 " Support expression interpolation ((${...})) inside template strings.
 syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=typescriptTemplateSubstitution containedin=graphqlFold keepend
@@ -40,7 +40,7 @@ syntax region graphqlTemplateString
       \ end=+`+me=s-1
       \ containedin=typescriptTemplate
       \ contained
-      \ contains=@GraphQLSyntax,typescriptTemplateSubstitution extend
+      \ contains=@typescriptGraphQL,typescriptTemplateSubstitution extend
 
 hi def link graphqlTemplateString typescriptTemplate
 hi def link graphqlTemplateExpression typescriptTemplateSubstitution


### PR DESCRIPTION
`@GraphQLSyntax` was unlikely to conflict with anything, but it's a better practice to prefix these groups with the main syntax name.