### PR TITLE
Ensure our plugin takes precedence

### DIFF
--- a/test/vimrc
+++ b/test/vimrc
@@ -1,6 +1,6 @@
 filetype off
+set runtimepath^=../
 set runtimepath+=../.bundle/vader.vim/
-set runtimepath+=../
 filetype plugin indent on
 syntax enable
 set nomore


### PR DESCRIPTION
Now that parts of this plugin are bundled with vim itself, we need to make sure our local plugin's files take precedence in 'runtimepath'.