### PR TITLE
Highlight escape sequences in strings

### DIFF
--- a/samples/kitchen-sink.graphql
+++ b/samples/kitchen-sink.graphql
@@ -48,6 +48,8 @@ fragment frag on Friend @onFragmentDefinition {
     bar: $b
     obj: {
       key: "value"
+      escaped: "hello\nworld\t\"quotes\"\\slash"
+      unicode: "fixed\u0000 braced\u{1F600}"
       block: """
       block string uses \"""
       """

--- a/syntax/graphql.vim
+++ b/syntax/graphql.vim
@@ -41,8 +41,13 @@ syn match graphqlOperator   "\M..." display
 syn keyword graphqlBoolean  true false
 syn keyword graphqlNull     null
 syn match   graphqlNumber   "-\=\<\%(0\|[1-9]\d*\)\%(\.\d\+\)\=\%([eE][-+]\=\d\+\)\=\>" display
-syn region  graphqlString   start=+"+  skip=+\\\\\|\\"+  end=+"\|$+
-syn region  graphqlString   start=+"""+ skip=+\\"""+ end=+"""+
+syn region  graphqlString   start=+"+  skip=+\\\\\|\\"+  end=+"\|$+  contains=graphqlEscape
+syn region  graphqlString   start=+"""+ skip=+\\"""+ end=+"""+  contains=graphqlEscape
+
+syn match   graphqlEscape   +\\["\\/bfnrt]+ contained display
+syn match   graphqlEscape   +\\u\x\{4}+     contained display
+syn match   graphqlEscape   +\\u{\x\+}+     contained display
+syn match   graphqlEscape   +\\""\"+        contained display
 
 syn keyword graphqlKeyword repeatable nextgroup=graphqlKeyword skipwhite
 syn keyword graphqlKeyword on nextgroup=graphqlType,graphqlDirectiveLocation skipwhite
@@ -88,6 +93,7 @@ hi def link graphqlBoolean          Boolean
 hi def link graphqlNull             Keyword
 hi def link graphqlNumber           Number
 hi def link graphqlString           String
+hi def link graphqlEscape           Special
 
 hi def link graphqlDirective        PreProc
 hi def link graphqlDirectiveLocation Special

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -53,6 +53,25 @@ Execute (String assertions):
   AssertEqual 'graphqlString', SyntaxOf('"""Block\nstring"""')
   AssertEqual 'graphqlString', SyntaxOf('"""Block\n\\"""\nstring"""')
 
+# https://spec.graphql.org/September2025/#EscapedCharacter
+Given graphql (Escape Sequences):
+  "hello\nworld"
+  "tab\there"
+  "quote\"end"
+  "slash\\path"
+  "null\u0000"
+  "emoji\u{1F600}"
+  """block\"""end"""
+
+Execute (Escape Sequence assertions):
+  AssertEqual 'graphqlEscape', SyntaxAt(1, 7)
+  AssertEqual 'graphqlEscape', SyntaxAt(2, 5)
+  AssertEqual 'graphqlEscape', SyntaxAt(3, 7)
+  AssertEqual 'graphqlEscape', SyntaxAt(4, 7)
+  AssertEqual 'graphqlEscape', SyntaxAt(5, 6)
+  AssertEqual 'graphqlEscape', SyntaxAt(6, 7)
+  AssertEqual 'graphqlEscape', SyntaxAt(7, 9)
+
 # https://graphql.github.io/graphql-spec/June2018/#sec-Field-Arguments
 Given graphql (Arguments):
   query queryName($site: Site = MOBILE) {


### PR DESCRIPTION
Add a graphqlEscape syntax group that highlights escape sequences within strings, including the braced unicode form (\u{H+}) added in the September 2025 specification.