### PR TITLE
Support multiline JavaScript function calls

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -24,7 +24,7 @@
 call graphql#embed_syntax('javaScriptGraphQL')
 
 let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
-let s:functions = '\%(' . join(graphql#javascript_functions(), '\|') . '\)'
+let s:functions = graphql#javascript_functions()
 
 exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ '
       \ 'nextgroup=graphqlTemplateString'
@@ -32,10 +32,14 @@ exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT '
       \ 'start=+' . s:tags . '\@20<=`+ skip=+\\\\\|\\`+ end=+`+ '
       \ 'contains=@javaScriptGraphQL,javaScriptSpecial,javaScriptEmbed,@htmlPreproc '
       \ 'extend'
-exec 'syntax region graphqlTemplateString matchgroup=javaScriptStringT '
-      \ 'start=+\%(' . s:functions . '\s*(\)\@40<=`+ skip=+\\\\\|\\`+ end=+`+ '
-      \ 'contains=@javaScriptGraphQL,javaScriptSpecial,javaScriptEmbed,@htmlPreproc '
-      \ 'extend'
+if !empty(s:functions)
+  exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\s*(+ '
+        \ 'nextgroup=graphqlFunctionLiteral skipwhite skipnl'
+  syntax region graphqlFunctionLiteral matchgroup=javaScriptStringT
+        \ start=+`+ skip=+\\\\\|\\`+ end=+`+
+        \ contains=@javaScriptGraphQL,javaScriptSpecial,javaScriptEmbed,@htmlPreproc
+        \ contained extend
+endif
 syntax region graphqlTemplateString matchgroup=javaScriptStringT
       \ start=+`#\s\{,4\}\(gql\|graphql\)\>\s*$+ skip=+\\\\\|\\`+ end=+`+
       \ contains=@javaScriptGraphQL,javaScriptSpecial,javaScriptEmbed,@htmlPreproc
@@ -46,21 +50,28 @@ syntax region graphqlTemplateExpression
       \ keepend
 
 hi def link graphqlTemplateString javaScriptStringT
+hi def link graphqlFunctionLiteral javaScriptStringT
 hi def link graphqlTaggedTemplate javaScriptEmbed
+hi def link graphqlFunctionCall javaScriptEmbed
 hi def link graphqlTemplateExpression javaScriptEmbed
 
-syn cluster htmlJavaScript add=graphqlTaggedTemplate
-syn cluster javaScriptEmbededExpr add=graphqlTaggedTemplate
-syn cluster graphqlTaggedTemplate add=graphqlTemplateString
+syn cluster htmlJavaScript add=graphqlTaggedTemplate,graphqlFunctionCall
+syn cluster javaScriptEmbededExpr add=graphqlTaggedTemplate,graphqlFunctionCall
+syn cluster graphqlTaggedTemplate add=graphqlTemplateString,graphqlFunctionLiteral
 
 " pangloss/vim-javascript
 if hlexists('jsTemplateString')
   exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString '
         \ 'start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ '
         \ 'contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial extend'
-  exec 'syntax region graphqlTemplateString matchgroup=jsTemplateString '
-        \ 'start=+\%(' . s:functions . '\s*(\)\@40<=`+ skip=+\\`+ end=+`+ '
-        \ 'contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial extend'
+  if !empty(s:functions)
+    exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\s*(+ '
+          \ 'nextgroup=graphqlFunctionLiteral skipwhite skipnl'
+    syntax region graphqlFunctionLiteral matchgroup=jsTemplateString
+          \ start=+`+ skip=+\\`+ end=+`+
+          \ contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial
+          \ contained extend
+  endif
   syntax region graphqlTemplateString matchgroup=jsTemplateString
         \ start=+`#\s\{,4\}\(gql\|graphql\)\>\s*$+ skip=+\\`+ end=+`+
         \ contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial extend
@@ -71,8 +82,10 @@ if hlexists('jsTemplateString')
 
   " Relink the default highlights we made above to the vim-javascript groups.
   hi! def link graphqlTemplateString jsTemplateString
+  hi! def link graphqlFunctionLiteral jsTemplateString
   hi! def link graphqlTaggedTemplate jsTaggedTemplate
+  hi! def link graphqlFunctionCall jsTaggedTemplate
   hi! def link graphqlTemplateExpression jsTemplateExpression
 
-  syn cluster jsExpression add=graphqlTemplateString,graphqlTaggedTemplate
+  syn cluster jsExpression add=graphqlTemplateString,graphqlTaggedTemplate,graphqlFunctionCall
 endif

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -24,11 +24,18 @@
 call graphql#embed_syntax('typescriptGraphQL')
 
 let s:tags = '\%(' . join(graphql#javascript_tags(), '\|') . '\)'
-let s:functions = '\%(' . join(graphql#javascript_functions(), '\|') . '\)'
+let s:functions = graphql#javascript_functions()
 
 exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+' . s:tags . '\@20<=`+ skip=+\\`+ end=+`+ contains=@typescriptGraphQL,typescriptTemplateSubstitution extend'
 exec 'syntax match graphqlTaggedTemplate +' . s:tags . '\ze`+ nextgroup=graphqlTemplateString'
-exec 'syntax region graphqlTemplateString matchgroup=typescriptTemplate start=+\%(' . s:functions . '\s*(\)\@40<=`+ skip=+\\`+ end=+`+ contains=@typescriptGraphQL,typescriptTemplateSubstitution containedin=typescriptFuncCallArg extend'
+if !empty(s:functions)
+  exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\s*(+ '
+        \ 'nextgroup=graphqlFunctionLiteral skipwhite skipnl'
+  syntax region graphqlFunctionLiteral matchgroup=typescriptTemplate
+        \ start=+`+ skip=+\\`+ end=+`+
+        \ contains=@typescriptGraphQL,typescriptTemplateSubstitution
+        \ containedin=typescriptFuncCallArg contained extend
+endif
 
 " Support expression interpolation ((${...})) inside template strings.
 syntax region graphqlTemplateExpression start=+${+ end=+}+ contained contains=typescriptTemplateSubstitution containedin=graphqlFold keepend
@@ -43,7 +50,8 @@ syntax region graphqlTemplateString
       \ contains=@typescriptGraphQL,typescriptTemplateSubstitution extend
 
 hi def link graphqlTemplateString typescriptTemplate
+hi def link graphqlFunctionLiteral typescriptTemplate
 hi def link graphqlTemplateExpression typescriptTemplateSubstitution
 
-syn cluster typescriptExpression add=graphqlTaggedTemplate
-syn cluster graphqlTaggedTemplate add=graphqlTemplateString
+syn cluster typescriptExpression add=graphqlTaggedTemplate,graphqlFunctionCall
+syn cluster graphqlTaggedTemplate add=graphqlTemplateString,graphqlFunctionLiteral

--- a/test/javascript/default.vader
+++ b/test/javascript/default.vader
@@ -85,6 +85,24 @@ Execute (Syntax assertions):
   AssertEqual 'graphqlTemplateExpression', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
 
+Given javascript (Template literal with a multiline graphql() function call):
+  graphql(
+    `
+    {
+      user(id: ${uid}) {
+        firstName
+        lastName
+      }
+    }
+    `,
+    [],
+  );
+
+Execute (Syntax assertions):
+  AssertEqual 'javascript', b:current_syntax
+  AssertEqual 'graphqlTemplateExpression', SyntaxOf('${uid}')
+  AssertEqual 'graphqlName', SyntaxOf('user')
+
 Given javascript (Template literal):
   const s = `text`;
 

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -102,3 +102,21 @@ Execute (Syntax assertions):
   AssertEqual 'typescriptTemplate', SyntaxOf('`')
   AssertEqual 'typescriptTemplateSB', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
+
+Given typescript (Template literal with a multiline graphql() function call):
+  graphql(
+    `
+    {
+      user(id: ${uid}) {
+        firstName
+        lastName
+      }
+    }
+    `,
+    [],
+  );
+
+Execute (Syntax assertions):
+  AssertEqual 'typescript', b:current_syntax
+  AssertEqual 'typescriptTemplateSB', SyntaxOf('${uid}')
+  AssertEqual 'graphqlName', SyntaxOf('user')


### PR DESCRIPTION
We now use `nextgroup` with `skipwhite skipnl` to chain from the function call match to the template literal region instead of an arbitrarily-limited lookbehind pattern.

These syntax patterns are only build when we have a list of configured JavaScript functions. This is set to `['graphql']` by default, but if it were empty, we previously would have produced an invalid regex.

This also applies to TypeScript.

Fixes: #127