### PR TITLE
Fix function call syntax with pangloss/vim-javascript

### DIFF
--- a/after/syntax/javascript/graphql.vim
+++ b/after/syntax/javascript/graphql.vim
@@ -35,8 +35,11 @@ if !empty(s:tags)
         \ 'extend'
 endif
 if !empty(s:functions)
-  exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\s*(+ '
-        \ 'nextgroup=graphqlFunctionLiteral skipwhite skipnl'
+  exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\ze\s*(+ '
+        \ 'nextgroup=graphqlFunctionArgs skipwhite skipnl'
+  syntax region graphqlFunctionArgs start=+(+ end=+)+
+        \ contains=graphqlFunctionLiteral
+        \ contained transparent extend
   syntax region graphqlFunctionLiteral matchgroup=javaScriptStringT
         \ start=+`+ skip=+\\\\\|\\`+ end=+`+
         \ contains=@javaScriptGraphQL,javaScriptSpecial,javaScriptEmbed,@htmlPreproc
@@ -69,8 +72,11 @@ if hlexists('jsTemplateString')
           \ 'contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial extend'
   endif
   if !empty(s:functions)
-    exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\s*(+ '
-          \ 'nextgroup=graphqlFunctionLiteral skipwhite skipnl'
+    exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\ze\s*(+ '
+          \ 'nextgroup=graphqlFunctionArgs skipwhite skipnl'
+    syntax region graphqlFunctionArgs matchgroup=jsParens start=+(+ end=+)+
+          \ contains=@jsExpression,graphqlFunctionLiteral
+          \ contained extend fold
     syntax region graphqlFunctionLiteral matchgroup=jsTemplateString
           \ start=+`+ skip=+\\`+ end=+`+
           \ contains=@javaScriptGraphQL,jsTemplateExpression,jsSpecial
@@ -88,7 +94,7 @@ if hlexists('jsTemplateString')
   hi! def link graphqlTemplateString jsTemplateString
   hi! def link graphqlFunctionLiteral jsTemplateString
   hi! def link graphqlTaggedTemplate jsTaggedTemplate
-  hi! def link graphqlFunctionCall jsTaggedTemplate
+  hi! def link graphqlFunctionCall jsFuncCall
   hi! def link graphqlTemplateExpression jsTemplateExpression
 
   syn cluster jsExpression add=graphqlTemplateString,graphqlTaggedTemplate,graphqlFunctionCall

--- a/after/syntax/typescript/graphql.vim
+++ b/after/syntax/typescript/graphql.vim
@@ -34,8 +34,8 @@ if !empty(s:tags)
         \ 'nextgroup=graphqlTemplateString'
 endif
 if !empty(s:functions)
-  exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\s*(+ '
-        \ 'nextgroup=graphqlFunctionLiteral skipwhite skipnl'
+  exec 'syntax match graphqlFunctionCall +\%(' . join(s:functions, '\|') . '\)\ze\s*(+ '
+        \ 'nextgroup=typescriptFuncCallArg skipwhite skipnl'
   syntax region graphqlFunctionLiteral matchgroup=typescriptTemplate
         \ start=+`+ skip=+\\`+ end=+`+
         \ contains=@typescriptGraphQL,typescriptTemplateSubstitution
@@ -56,6 +56,7 @@ syntax region graphqlTemplateString
 
 hi def link graphqlTemplateString typescriptTemplate
 hi def link graphqlFunctionLiteral typescriptTemplate
+hi def link graphqlFunctionCall typescriptFuncName
 hi def link graphqlTemplateExpression typescriptTemplateSubstitution
 
 syn cluster typescriptExpression add=graphqlTaggedTemplate,graphqlFunctionCall

--- a/test/javascript/default.vader
+++ b/test/javascript/default.vader
@@ -82,8 +82,10 @@ Given javascript (Template literal with a graphql() function):
 
 Execute (Syntax assertions):
   AssertEqual 'javascript', b:current_syntax
+  AssertEqual 'graphqlFunctionCall', SyntaxOf('graphql')
   AssertEqual 'graphqlTemplateExpression', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
+  AssertNotEqual 'jsParensError', SyntaxOf(')')
 
 Given javascript (Template literal with a multiline graphql() function call):
   graphql(
@@ -100,8 +102,10 @@ Given javascript (Template literal with a multiline graphql() function call):
 
 Execute (Syntax assertions):
   AssertEqual 'javascript', b:current_syntax
+  AssertEqual 'graphqlFunctionCall', SyntaxOf('graphql')
   AssertEqual 'graphqlTemplateExpression', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
+  AssertNotEqual 'jsParensError', SyntaxOf(')')
 
 Given javascript (Template literal):
   const s = `text`;

--- a/test/typescript/default.vader
+++ b/test/typescript/default.vader
@@ -99,6 +99,7 @@ Given typescript (Template literal with a graphql() function):
 
 Execute (Syntax assertions):
   AssertEqual 'typescript', b:current_syntax
+  AssertEqual 'graphqlFunctionCall', SyntaxOf('graphql')
   AssertEqual 'typescriptTemplate', SyntaxOf('`')
   AssertEqual 'typescriptTemplateSB', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')
@@ -118,5 +119,6 @@ Given typescript (Template literal with a multiline graphql() function call):
 
 Execute (Syntax assertions):
   AssertEqual 'typescript', b:current_syntax
+  AssertEqual 'graphqlFunctionCall', SyntaxOf('graphql')
   AssertEqual 'typescriptTemplateSB', SyntaxOf('${uid}')
   AssertEqual 'graphqlName', SyntaxOf('user')


### PR DESCRIPTION
The graphqlFunctionCall match was consuming the opening parenthesis, which prevented pangloss/vim-javascript from starting a jsParen region and caused the closing parenthesis to be highlighted as jsParensError.

We now stop the match before the closing paren using \ze and then chain to a new args region that contains the parenthesized expression. For TypeScript, we can reuse the existing typescriptFuncCallArg region.

Also link graphqlFunctionCall to more specific function groups where possible (e.g. jsFuncCall, typescriptFuncName).

Fixes: https://github.com/jparise/vim-graphql/pull/128#issuecomment-4239462214